### PR TITLE
[testutil] Add MatchGraphQLError.

### DIFF
--- a/graphql/lexer/lexer_test.go
+++ b/graphql/lexer/lexer_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/botobag/artemis/graphql"
 	"github.com/botobag/artemis/graphql/lexer"
 	"github.com/botobag/artemis/graphql/token"
+	"github.com/botobag/artemis/internal/testutil"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -36,11 +37,11 @@ func lexOne(str string) (*token.Token, error) {
 
 func expectSyntaxError(text string, message string, location graphql.ErrorLocation) {
 	_, err := lexOne(text)
-	Expect(err).Should(PointTo(MatchFields(IgnoreExtras, Fields{
-		"Message":   ContainSubstring(message),
-		"Locations": Equal([]graphql.ErrorLocation{location}),
-		"Kind":      Equal(graphql.ErrKindSyntax),
-	})))
+	Expect(err).Should(testutil.MatchGraphQLError(
+		testutil.MessagaContainSubstring(message),
+		testutil.LocationEqual(location),
+		testutil.KindIs(graphql.ErrKindSyntax),
+	))
 }
 
 // A custom Gomega matcher to skip matching Prev and Next fields in the Token.

--- a/internal/testutil/match_graphql_error.go
+++ b/internal/testutil/match_graphql_error.go
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2018, The Artemis Authors.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package testutil
+
+import (
+	"github.com/botobag/artemis/graphql"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
+)
+
+// ErrorFieldsMatcher sets up fields to match.
+type ErrorFieldsMatcher func(gstruct.Fields)
+
+// MessagaContainSubstring matches message in a graphql.Error to contain the specified string.
+func MessagaContainSubstring(s string) ErrorFieldsMatcher {
+	return func(fields gstruct.Fields) {
+		fields["Message"] = gomega.ContainSubstring(s)
+	}
+}
+
+// LocationEqual matches the locations in the error to contain the only specified location.
+func LocationEqual(location graphql.ErrorLocation) ErrorFieldsMatcher {
+	return func(fields gstruct.Fields) {
+		fields["Locations"] = gomega.Equal([]graphql.ErrorLocation{location})
+	}
+}
+
+// KindIs matches the kind in the error to be the same as the given one.
+func KindIs(errKind graphql.ErrKind) ErrorFieldsMatcher {
+	return func(fields gstruct.Fields) {
+		fields["Kind"] = gomega.Equal(errKind)
+	}
+}
+
+// MatchGraphQLError matches a graphql.Error with given fields.
+//
+// The following example matches a graphql.Error including "Unterminated string" in the message and
+// the error kind should match graphql.ErrKindSyntax.
+//
+//		Expect(err).Should(MatchGraphQLError(
+//			MessagaContainSubstring("Unterminated string"),
+//			KindIs(graphql.ErrKindSyntax),
+//		))
+func MatchGraphQLError(matchers ...ErrorFieldsMatcher) types.GomegaMatcher {
+	fields := gstruct.Fields{}
+	for _, matcher := range matchers {
+		matcher(fields)
+	}
+	return gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, fields))
+}


### PR DESCRIPTION
`MatchGraphQLError` provides a way to match only specified fields for a
`graphql.Error`. It is based on `gstruct.MatchFields` from Gomega but
provides a type-safe way.