### PR TITLE
[types] Remove ThisIsGraphQL*TypeDefinition marker interface.

### DIFF
--- a/graphql/enum.go
+++ b/graphql/enum.go
@@ -179,7 +179,7 @@ func DefaultEnumResultCoercerFactory(lookupStrategy DefaultEnumResultCoercerLook
 // EnumConfig provides specification to define an Enum type. It is served as a convenient way to
 // create an EnumTypeDefinition for creating an enum type.
 type EnumConfig struct {
-	ThisIsEnumTypeDefinition
+	ThisIsTypeDefinition
 
 	// Name of the enum type
 	Name string

--- a/graphql/input_object.go
+++ b/graphql/input_object.go
@@ -111,7 +111,7 @@ func (f *inputField) DefaultValue() interface{} {
 // InputObjectConfig provides specification to define a InputObject type. It is served as a
 // convenient way to create a InputObjectTypeDefinition for creating an input object type.
 type InputObjectConfig struct {
-	ThisIsInputObjectTypeDefinition
+	ThisIsTypeDefinition
 
 	// Name of the defining InputObject
 	Name string

--- a/graphql/interface.go
+++ b/graphql/interface.go
@@ -19,7 +19,7 @@ package graphql
 // InterfaceConfig provides specification to define a Interface type. It is served as a convenient way to
 // create a InterfaceTypeDefinition for creating an interface type.
 type InterfaceConfig struct {
-	ThisIsInterfaceTypeDefinition
+	ThisIsTypeDefinition
 
 	// Name of the defining Interface
 	Name string

--- a/graphql/list.go
+++ b/graphql/list.go
@@ -57,7 +57,7 @@ func (creator *listTypeCreator) Finalize(t Type, typeDefResolver typeDefinitionR
 // listTypeDefinitionOf wraps a TypeDefinition of the element type and implements
 // ListTypeDefinition.
 type listTypeDefinitionOf struct {
-	ThisIsListTypeDefinition
+	ThisIsTypeDefinition
 	elementTypeDef TypeDefinition
 }
 
@@ -78,7 +78,7 @@ func ListOf(elementTypeDef TypeDefinition) ListTypeDefinition {
 // listTypeDefinitionOfType wraps a Type of the element type and implements
 // ListTypeDefinition.
 type listTypeDefinitionOfType struct {
-	ThisIsListTypeDefinition
+	ThisIsTypeDefinition
 	elementType Type
 }
 

--- a/graphql/non_null.go
+++ b/graphql/non_null.go
@@ -41,7 +41,7 @@ func (creator *nonNullTypeCreator) LoadDataAndNew() (Type, error) {
 // Finalize implements typeCreator.
 func (creator *nonNullTypeCreator) Finalize(t Type, typeDefResolver typeDefinitionResolver) error {
 	// Resolve element type.
-	elementType, err := typeDefResolver(creator.typeDef.ElementType())
+	elementType, err := typeDefResolver(creator.typeDef.InnerType())
 	if err != nil {
 		return err
 	} else if elementType == nil {
@@ -59,14 +59,14 @@ func (creator *nonNullTypeCreator) Finalize(t Type, typeDefResolver typeDefiniti
 // nonNullTypeDefinitionOf wraps a TypeDefinition of the element type and implements
 // NonNullTypeDefinition.
 type nonNullTypeDefinitionOf struct {
-	ThisIsNonNullTypeDefinition
+	ThisIsTypeDefinition
 	elementTypeDef TypeDefinition
 }
 
 var _ NonNullTypeDefinition = nonNullTypeDefinitionOf{}
 
-// ElementType implements NonNullTypeDefinition.
-func (typeDef nonNullTypeDefinitionOf) ElementType() TypeDefinition {
+// InnerType implements NonNullTypeDefinition.
+func (typeDef nonNullTypeDefinitionOf) InnerType() TypeDefinition {
 	return typeDef.elementTypeDef
 }
 
@@ -80,14 +80,14 @@ func NonNullOf(elementTypeDef TypeDefinition) NonNullTypeDefinition {
 // nonNullTypeDefinitionOfType wraps a Type of the element type and implements
 // NonNullTypeDefinition.
 type nonNullTypeDefinitionOfType struct {
-	ThisIsNonNullTypeDefinition
+	ThisIsTypeDefinition
 	elementType Type
 }
 
 var _ NonNullTypeDefinition = nonNullTypeDefinitionOfType{}
 
-// ElementType implements NonNullTypeDefinition.
-func (typeDef nonNullTypeDefinitionOfType) ElementType() TypeDefinition {
+// InnerType implements NonNullTypeDefinition.
+func (typeDef nonNullTypeDefinitionOfType) InnerType() TypeDefinition {
 	return T(typeDef.elementType)
 }
 

--- a/graphql/object.go
+++ b/graphql/object.go
@@ -19,7 +19,7 @@ package graphql
 // ObjectConfig provides specification to define a Object type. It is served as a convenient way to
 // create a ObjectTypeDefinition for creating an object type.
 type ObjectConfig struct {
-	ThisIsObjectTypeDefinition
+	ThisIsTypeDefinition
 
 	// Name of the defining Object
 	Name string

--- a/graphql/scalar.go
+++ b/graphql/scalar.go
@@ -40,7 +40,7 @@ func (coercer *defaultScalarInputCoercer) CoerceArgumentValue(value ast.Value) (
 // ScalarConfig provides specification to define a scalar type. It is served as a convenient way to
 // create a ScalarTypeDefinition for creating a scalar type.
 type ScalarConfig struct {
-	ThisIsScalarTypeDefinition
+	ThisIsTypeDefinition
 
 	// Name of the scalar type
 	Name string

--- a/graphql/type_definitions.go
+++ b/graphql/type_definitions.go
@@ -89,7 +89,7 @@ func T(t Type) TypeDefinition {
 // InterfaceTypeDefinition interfaces. This allows InterfaceType being able to use in specifying
 // implementing interfaces when defining Object (i.e., ObjectTypeData.Interfaces).
 type interfaceTypeWrapperTypeDefinition struct {
-	ThisIsInterfaceTypeDefinition
+	ThisIsTypeDefinition
 	i Interface
 }
 
@@ -128,15 +128,6 @@ type ScalarTypeData struct {
 	Description string
 }
 
-// ThisIsScalarTypeDefinition is a marker struct intended to be embedded in every
-// ScalarTypeDefinition implementation.
-type ThisIsScalarTypeDefinition struct {
-	ThisIsTypeDefinition
-}
-
-// ThisIsGraphQLScalarTypeDefinition implements ThisIsGraphQLScalarTypeDefinition.
-func (ThisIsScalarTypeDefinition) ThisIsGraphQLScalarTypeDefinition() {}
-
 // ScalarTypeDefinition provides data accessors that are required for defining a Scalar.
 type ScalarTypeDefinition interface {
 	TypeDefinition
@@ -151,9 +142,6 @@ type ScalarTypeDefinition interface {
 	// NewInputCoercer creates an ScalarInputCoercer instance for the defining Scalar type object
 	// during its initialization.
 	NewInputCoercer(scalar Scalar) (ScalarInputCoercer, error)
-
-	// ThisIsGraphQLScalarTypeDefinition puts a special mark for a ScalarTypeDefinition objects.
-	ThisIsGraphQLScalarTypeDefinition()
 }
 
 //===-----------------------------------------------------------------------------------------====//
@@ -213,15 +201,6 @@ func (f CoerceEnumResultFunc) Coerce(value interface{}) (EnumValue, error) {
 	return f(value)
 }
 
-// ThisIsEnumTypeDefinition is a marker struct intended to be embedded in every EnumTypeDefinition
-// implementation.
-type ThisIsEnumTypeDefinition struct {
-	ThisIsTypeDefinition
-}
-
-// ThisIsGraphQLEnumTypeDefinition implements ThisIsGraphQLEnumTypeDefinition.
-func (ThisIsEnumTypeDefinition) ThisIsGraphQLEnumTypeDefinition() {}
-
 // EnumTypeDefinition provides data accessors that are required for defining a Enum.
 type EnumTypeDefinition interface {
 	TypeDefinition
@@ -232,9 +211,6 @@ type EnumTypeDefinition interface {
 	// NewResultCoercer creates a EnumResultCoercer instance for the defining Enum type object during
 	// its initialization.
 	NewResultCoercer(enum Enum) (EnumResultCoercer, error)
-
-	// ThisIsGraphQLEnumTypeDefinition puts a special mark for a EnumTypeDefinition objects.
-	ThisIsGraphQLEnumTypeDefinition()
 }
 
 //===-----------------------------------------------------------------------------------------====//
@@ -256,24 +232,12 @@ type ObjectTypeData struct {
 	Fields Fields
 }
 
-// ThisIsObjectTypeDefinition is a marker struct intended to be embedded in every
-// ObjectTypeDefinition implementation.
-type ThisIsObjectTypeDefinition struct {
-	ThisIsTypeDefinition
-}
-
-// ThisIsGraphQLObjectTypeDefinition implements ThisIsGraphQLObjectTypeDefinition.
-func (ThisIsObjectTypeDefinition) ThisIsGraphQLObjectTypeDefinition() {}
-
 // ObjectTypeDefinition provides data accessors that are required for defining a Object.
 type ObjectTypeDefinition interface {
 	TypeDefinition
 
 	// TypeData reads data from the definition for the defining enum.
 	TypeData() ObjectTypeData
-
-	// ThisIsGraphQLObjectTypeDefinition puts a special mark for a ObjectTypeDefinition objects.
-	ThisIsGraphQLObjectTypeDefinition()
 }
 
 //===-----------------------------------------------------------------------------------------====//
@@ -330,15 +294,6 @@ type ResolveTypeParams struct {
 	Context context.Context
 }
 
-// ThisIsInterfaceTypeDefinition is a marker struct intended to be embedded in every
-// InterfaceTypeDefinition implementation.
-type ThisIsInterfaceTypeDefinition struct {
-	ThisIsTypeDefinition
-}
-
-// ThisIsGraphQLInterfaceTypeDefinition implements ThisIsGraphQLInterfaceTypeDefinition.
-func (ThisIsInterfaceTypeDefinition) ThisIsGraphQLInterfaceTypeDefinition() {}
-
 // InterfaceTypeDefinition provides data accessors that are required for defining a Interface.
 type InterfaceTypeDefinition interface {
 	TypeDefinition
@@ -349,9 +304,6 @@ type InterfaceTypeDefinition interface {
 	// NewTypeResolver creates a TypeResolver instance for the defining Interface during its
 	// initialization.
 	NewTypeResolver(iface Interface) (TypeResolver, error)
-
-	// ThisIsGraphQLInterfaceTypeDefinition puts a special mark for a InterfaceTypeDefinition objects.
-	ThisIsGraphQLInterfaceTypeDefinition()
 }
 
 //===-----------------------------------------------------------------------------------------====//
@@ -370,15 +322,6 @@ type UnionTypeData struct {
 	PossibleTypes []ObjectTypeDefinition
 }
 
-// ThisIsUnionTypeDefinition is a marker struct intended to be embedded in every UnionTypeDefinition
-// implementation.
-type ThisIsUnionTypeDefinition struct {
-	ThisIsTypeDefinition
-}
-
-// ThisIsGraphQLUnionTypeDefinition implements ThisIsGraphQLUnionTypeDefinition.
-func (ThisIsUnionTypeDefinition) ThisIsGraphQLUnionTypeDefinition() {}
-
 // UnionTypeDefinition provides data accessors that are required for defining a Union.
 type UnionTypeDefinition interface {
 	TypeDefinition
@@ -389,9 +332,6 @@ type UnionTypeDefinition interface {
 	// NewTypeResolver creates a TypeResolver instance for the defining Union during its
 	// initialization.
 	NewTypeResolver(union Union) (TypeResolver, error)
-
-	// ThisIsGraphQLUnionTypeDefinition puts a special mark for a UnionTypeDefinition objects.
-	ThisIsGraphQLUnionTypeDefinition()
 }
 
 //===-----------------------------------------------------------------------------------------====//
@@ -410,39 +350,17 @@ type InputObjectTypeData struct {
 	Fields InputFields
 }
 
-// ThisIsInputObjectTypeDefinition is a marker struct intended to be embedded in every
-// InputObjectTypeDefinition implementation.
-type ThisIsInputObjectTypeDefinition struct {
-	ThisIsTypeDefinition
-}
-
-// ThisIsGraphQLInputObjectTypeDefinition implements ThisIsGraphQLInputObjectTypeDefinition.
-func (ThisIsInputObjectTypeDefinition) ThisIsGraphQLInputObjectTypeDefinition() {}
-
 // InputObjectTypeDefinition provides data accessors that are required for defining a InputObject.
 type InputObjectTypeDefinition interface {
 	TypeDefinition
 
 	// TypeData reads data from the definition for the defining enum.
 	TypeData() InputObjectTypeData
-
-	// ThisIsGraphQLInputObjectTypeDefinition puts a special mark for a InputObjectTypeDefinition
-	// objects.
-	ThisIsGraphQLInputObjectTypeDefinition()
 }
 
 //===-----------------------------------------------------------------------------------------====//
 // List Type Definition
 //===-----------------------------------------------------------------------------------------====//
-
-// ThisIsListTypeDefinition is a marker struct intended to be embedded in every
-// ListTypeDefinition implementation.
-type ThisIsListTypeDefinition struct {
-	ThisIsTypeDefinition
-}
-
-// ThisIsGraphQLListTypeDefinition implements ThisIsGraphQLListTypeDefinition.
-func (ThisIsListTypeDefinition) ThisIsGraphQLListTypeDefinition() {}
 
 // ListTypeDefinition provides data accessors that are required for defining a List.
 type ListTypeDefinition interface {
@@ -450,33 +368,16 @@ type ListTypeDefinition interface {
 
 	// ElementType specifies the type being wrapped in the List type.
 	ElementType() TypeDefinition
-
-	// ThisIsGraphQLListTypeDefinition puts a special mark for a ListTypeDefinition
-	// objects.
-	ThisIsGraphQLListTypeDefinition()
 }
 
 //===-----------------------------------------------------------------------------------------====//
 // NonNull Type Definition
 //===-----------------------------------------------------------------------------------------====//
 
-// ThisIsNonNullTypeDefinition is a marker struct intended to be embedded in every
-// NonNullTypeDefinition implementation.
-type ThisIsNonNullTypeDefinition struct {
-	ThisIsTypeDefinition
-}
-
-// ThisIsGraphQLNonNullTypeDefinition implements ThisIsGraphQLNonNullTypeDefinition.
-func (ThisIsNonNullTypeDefinition) ThisIsGraphQLNonNullTypeDefinition() {}
-
 // NonNullTypeDefinition provides data accessors that are required for defining a NonNull.
 type NonNullTypeDefinition interface {
 	TypeDefinition
 
-	// ElementType specifies the type being wrapped in the NonNull type.
-	ElementType() TypeDefinition
-
-	// ThisIsGraphQLNonNullTypeDefinition puts a special mark for a NonNullTypeDefinition
-	// objects.
-	ThisIsGraphQLNonNullTypeDefinition()
+	// InnerType specifies the type being wrapped in the NonNull type.
+	InnerType() TypeDefinition
 }

--- a/graphql/union.go
+++ b/graphql/union.go
@@ -19,7 +19,7 @@ package graphql
 // UnionConfig provides specification to define a Union type. It is served as a convenient way to
 // create a UnionTypeDefinition for creating a union type.
 type UnionConfig struct {
-	ThisIsUnionTypeDefinition
+	ThisIsTypeDefinition
 
 	// Name of the defining Union
 	Name string


### PR DESCRIPTION
`ThisIsTypeDefinition` is kept to make `TypeDefinition` a non-trivial
interface.

TypeDefinition usually contains an interface TypeData which returns a
value (e.g., ScalarTypeData) which is only meaningful to NewType and is
not used elsewhere. Removing it to make define TypeDefinition easier and
increase code coverage.

This requires renaiming `ElementType` to `InnerType` in
`NonNullTypeDefinition` to distinguish it from `ListTypeDefinition`.

Closes #86.