### PR TITLE
[types] Implement ScalarAlias.

### DIFF
--- a/graphql/enum_test.go
+++ b/graphql/enum_test.go
@@ -21,35 +21,11 @@ import (
 	"fmt"
 
 	"github.com/botobag/artemis/graphql"
-	"github.com/botobag/artemis/graphql/executor"
-	"github.com/botobag/artemis/graphql/parser"
-	"github.com/botobag/artemis/graphql/token"
 	"github.com/botobag/artemis/internal/testutil"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
-
-func executeQueryWithParams(schema *graphql.Schema, query string, params map[string]interface{}) executor.ExecutionResult {
-	document, err := parser.Parse(token.NewSource(&token.SourceConfig{
-		Body: token.SourceBody([]byte(query)),
-	}), parser.ParseOptions{})
-	Expect(err).ShouldNot(HaveOccurred())
-
-	operation, errs := executor.Prepare(executor.PrepareParams{
-		Schema:   schema,
-		Document: document,
-	})
-	Expect(errs.HaveOccurred()).ShouldNot(BeTrue())
-
-	return operation.Execute(context.Background(), executor.ExecuteParams{
-		VariableValues: params,
-	})
-}
-
-func executeQuery(schema *graphql.Schema, query string) executor.ExecutionResult {
-	return executeQueryWithParams(schema, query, nil)
-}
 
 var _ = Describe("Enum", func() {
 

--- a/graphql/graphql_suite_test.go
+++ b/graphql/graphql_suite_test.go
@@ -17,7 +17,13 @@
 package graphql_test
 
 import (
+	"context"
 	"testing"
+
+	"github.com/botobag/artemis/graphql"
+	"github.com/botobag/artemis/graphql/executor"
+	"github.com/botobag/artemis/graphql/parser"
+	"github.com/botobag/artemis/graphql/token"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -26,4 +32,25 @@ import (
 func TestGraphQLCore(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "GraphQL Core Suite")
+}
+
+func executeQueryWithParams(schema *graphql.Schema, query string, params map[string]interface{}) executor.ExecutionResult {
+	document, err := parser.Parse(token.NewSource(&token.SourceConfig{
+		Body: token.SourceBody([]byte(query)),
+	}), parser.ParseOptions{})
+	Expect(err).ShouldNot(HaveOccurred())
+
+	operation, errs := executor.Prepare(executor.PrepareParams{
+		Schema:   schema,
+		Document: document,
+	})
+	Expect(errs.HaveOccurred()).ShouldNot(BeTrue())
+
+	return operation.Execute(context.Background(), executor.ExecuteParams{
+		VariableValues: params,
+	})
+}
+
+func executeQuery(schema *graphql.Schema, query string) executor.ExecutionResult {
+	return executeQueryWithParams(schema, query, nil)
 }

--- a/graphql/scalar_alias.go
+++ b/graphql/scalar_alias.go
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2018, The Artemis Authors.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package graphql
+
+import (
+	"github.com/botobag/artemis/graphql/ast"
+)
+
+// defaultScalarInputCoercer is used for scalar that doesn't provide coercer for processing input values.
+
+// ScalarAliasConfig provides specification to define a scalar type. It is served as a convenient way to
+// create a ScalarAliasTypeDefinition for creating a scalar type.
+type ScalarAliasConfig struct {
+	ThisIsTypeDefinition
+
+	AliasFor Scalar
+
+	// ResultCoercer serializes value for return in execution result. If omitted, the newly created
+	// ScalarAlias will apply result coercion as its aliasing Scalar.
+	ResultCoercer ScalarResultCoercer
+
+	// InputCoercer parses input value given to the scalar field. If omitted, the newly created
+	// ScalarAlias will apply input coercion as its aliasing Scalar.
+	InputCoercer ScalarInputCoercer
+}
+
+var (
+	_ TypeDefinition            = (*ScalarAliasConfig)(nil)
+	_ ScalarAliasTypeDefinition = (*ScalarAliasConfig)(nil)
+)
+
+// TypeData implements ScalarAliasTypeDefinition.
+func (config *ScalarAliasConfig) TypeData() ScalarAliasTypeData {
+	return ScalarAliasTypeData{
+		AliasFor: config.AliasFor,
+	}
+}
+
+// NewResultCoercer implments ScalarAliasTypeDefinition.
+func (config *ScalarAliasConfig) NewResultCoercer(alias ScalarAlias) (ScalarResultCoercer, error) {
+	return config.ResultCoercer, nil
+}
+
+// NewInputCoercer implments ScalarAliasTypeDefinition.
+func (config *ScalarAliasConfig) NewInputCoercer(alias ScalarAlias) (ScalarInputCoercer, error) {
+	return config.InputCoercer, nil
+}
+
+// scalarAliasTypeCreator is given to newTypeImpl for creating a scalarAlias.
+type scalarAliasTypeCreator struct {
+	typeDef ScalarAliasTypeDefinition
+}
+
+// scalarAliasTypeCreator implements typeCreator.
+var _ typeCreator = (*scalarAliasTypeCreator)(nil)
+
+// TypeDefinition implements typeCreator.
+func (creator *scalarAliasTypeCreator) TypeDefinition() TypeDefinition {
+	return creator.typeDef
+}
+
+// LoadDataAndNew implements typeCreator.
+func (creator *scalarAliasTypeCreator) LoadDataAndNew() (Type, error) {
+	typeDef := creator.typeDef
+	// Load data.
+	data := typeDef.TypeData()
+
+	// Must provide the type being aliased to.
+	if data.AliasFor == nil {
+		return nil, NewError("Must provide aliasing Scalar type for ScalarAlias.")
+	}
+
+	// Create instance.
+	return &scalarAlias{
+		Scalar: typeDef.TypeData().AliasFor,
+	}, nil
+}
+
+// Finalize implements typeCreator.
+func (creator *scalarAliasTypeCreator) Finalize(t Type, typeDefResolver typeDefinitionResolver) error {
+	alias := t.(*scalarAlias)
+	typeDef := creator.typeDef
+
+	// Create result coercer.
+	resultCoercer, err := typeDef.NewResultCoercer(alias)
+	if err != nil {
+		return err
+	}
+	alias.resultCoercer = resultCoercer
+
+	// Create input coercer.
+	inputCoercer, err := typeDef.NewInputCoercer(alias)
+	if err != nil {
+		return err
+	}
+	alias.inputCoercer = inputCoercer
+
+	return nil
+}
+
+// scalarAlias is our built-in implementation for ScalarAlias. It is configured with and built from
+// ScalarAliasTypeDefinition.
+type scalarAlias struct {
+	Scalar
+	resultCoercer ScalarResultCoercer
+	inputCoercer  ScalarInputCoercer
+}
+
+var _ ScalarAlias = (*scalarAlias)(nil)
+
+// NewScalarAlias defines a scalar type from a ScalarAliasTypeDefinition.
+func NewScalarAlias(typeDef ScalarAliasTypeDefinition) (ScalarAlias, error) {
+	t, err := newTypeImpl(&scalarAliasTypeCreator{
+		typeDef: typeDef,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return t.(*scalarAlias), nil
+}
+
+// MustNewScalarAlias is a convenience function equivalent to NewScalarAlias but panics on failure
+// instead of returning an error.
+func MustNewScalarAlias(typeDef ScalarAliasTypeDefinition) ScalarAlias {
+	s, err := NewScalarAlias(typeDef)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+// AliasFor implements ScalarAlias.
+func (a *scalarAlias) AliasFor() Scalar {
+	return a.Scalar
+}
+
+// CoerceResultValue implmenets LeafType.
+func (a *scalarAlias) CoerceResultValue(value interface{}) (interface{}, error) {
+	if a.resultCoercer == nil {
+		return a.Scalar.CoerceResultValue(value)
+	}
+	return a.resultCoercer.CoerceResultValue(value)
+}
+
+// CoerceVariableValue implmenets ScalarAlias.
+func (a *scalarAlias) CoerceVariableValue(value interface{}) (interface{}, error) {
+	if a.inputCoercer == nil {
+		return a.Scalar.CoerceVariableValue(value)
+	}
+	return a.inputCoercer.CoerceVariableValue(value)
+}
+
+// CoerceArgumentValue implmenets ScalarAlias.
+func (a *scalarAlias) CoerceArgumentValue(value ast.Value) (interface{}, error) {
+	if a.inputCoercer == nil {
+		return a.Scalar.CoerceArgumentValue(value)
+	}
+	return a.inputCoercer.CoerceArgumentValue(value)
+}

--- a/graphql/scalar_alias_test.go
+++ b/graphql/scalar_alias_test.go
@@ -1,0 +1,336 @@
+/**
+ * Copyright (c) 2018, The Artemis Authors.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package graphql_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/botobag/artemis/graphql"
+	"github.com/botobag/artemis/graphql/ast"
+	"github.com/botobag/artemis/internal/testutil"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// The following test is translated from:
+//
+//  https://github.com/sangria-graphql/sangria/blob/0bf8053/src/test/scala/sangria/execution/ScalarAliasSpec.scala
+//
+// The license is reproduced as followed:
+//
+// Sangria License
+// ===============
+//
+// Copyright 2018, The Sangria Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+type UserID struct {
+	ID string
+}
+
+type UserIDCoercer struct{}
+
+func (UserIDCoercer) CoerceResultValue(value interface{}) (interface{}, error) {
+	userID, ok := value.(UserID)
+	if !ok {
+		return nil, errors.New("unexpected value type presented to UserId; Expected an UserID value")
+	}
+	return graphql.String().CoerceResultValue(userID.ID)
+}
+
+func (UserIDCoercer) coerceInputValue(value interface{}) (interface{}, error) {
+	id, ok := value.(string)
+	if !ok {
+		return nil, errors.New("unexpected input value type to UserId; Expected a string value")
+	}
+	return UserID{
+		ID: id,
+	}, nil
+}
+
+func (coercer UserIDCoercer) CoerceVariableValue(value interface{}) (interface{}, error) {
+	value, err := graphql.String().CoerceVariableValue(value)
+	if err != nil {
+		return nil, err
+	}
+	return coercer.coerceInputValue(value)
+}
+
+func (coercer UserIDCoercer) CoerceArgumentValue(value ast.Value) (interface{}, error) {
+	v, err := graphql.String().CoerceArgumentValue(value)
+	if err != nil {
+		return nil, err
+	}
+	return coercer.coerceInputValue(v)
+}
+
+type PositiveIntCoercer struct{}
+
+func (PositiveIntCoercer) coerceInputValue(value interface{}) (interface{}, error) {
+	i, ok := value.(int)
+	if !ok {
+		return nil, errors.New("unexpected input value type to PositiveInt variable; Expected an int value")
+	}
+
+	if i <= 0 {
+		return nil, graphql.NewCoercionError("Int cannot represent %d: predicate failed: (%d > 0)", i, i)
+	}
+
+	return i, nil
+}
+
+func (coercer PositiveIntCoercer) CoerceVariableValue(value interface{}) (interface{}, error) {
+	value, err := graphql.Int().CoerceVariableValue(value)
+	if err != nil {
+		return nil, err
+	}
+	return coercer.coerceInputValue(value)
+}
+
+func (coercer PositiveIntCoercer) CoerceArgumentValue(value ast.Value) (interface{}, error) {
+	v, err := graphql.Int().CoerceArgumentValue(value)
+	if err != nil {
+		return nil, err
+	}
+	return coercer.coerceInputValue(v)
+}
+
+var _ = Describe("ScalarAlias", func() {
+	It("rejects creating type without aliasing scalar", func() {
+		_, err := graphql.NewScalarAlias(&graphql.ScalarAliasConfig{
+			AliasFor: nil,
+		})
+		Expect(err).Should(MatchError("Must provide aliasing Scalar type for ScalarAlias."))
+
+		Expect(func() {
+			graphql.MustNewScalarAlias(&graphql.ScalarAliasConfig{})
+		}).Should(Panic())
+	})
+
+	It("accepts creating type without specifying coercers", func() {
+		_, err := graphql.NewScalarAlias(&graphql.ScalarAliasConfig{
+			AliasFor:      graphql.Int(),
+			ResultCoercer: nil,
+			InputCoercer:  nil,
+		})
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	Describe("Type System: ScalarAlias Values", func() {
+		type User struct {
+			ID   UserID
+			ID2  *UserID
+			Name string
+			Num  int
+		}
+
+		var Schema *graphql.Schema
+
+		BeforeEach(func() {
+			userIDType := &graphql.ScalarAliasConfig{
+				AliasFor:      graphql.String(),
+				ResultCoercer: UserIDCoercer{},
+				InputCoercer:  UserIDCoercer{},
+			}
+
+			positiveIntType := &graphql.ScalarAliasConfig{
+				AliasFor:     graphql.Int(),
+				InputCoercer: PositiveIntCoercer{},
+			}
+
+			userType := &graphql.ObjectConfig{
+				Name: "User",
+				Fields: graphql.Fields{
+					"id": {
+						Type: graphql.NonNullOf(userIDType),
+						Resolver: graphql.FieldResolverFunc(func(ctx context.Context, source interface{}, info graphql.ResolveInfo) (interface{}, error) {
+							return source.(*User).ID, nil
+						}),
+					},
+					"id2": {
+						Type: userIDType,
+						Resolver: graphql.FieldResolverFunc(func(ctx context.Context, source interface{}, info graphql.ResolveInfo) (interface{}, error) {
+							user := source.(*User)
+							if user.ID2 != nil {
+								return *user.ID2, nil
+							}
+							return nil, nil
+						}),
+					},
+					"name": {
+						Type: graphql.T(graphql.String()),
+						Resolver: graphql.FieldResolverFunc(func(ctx context.Context, source interface{}, info graphql.ResolveInfo) (interface{}, error) {
+							return source.(*User).Name, nil
+						}),
+					},
+					"num": {
+						Type: positiveIntType,
+						Resolver: graphql.FieldResolverFunc(func(ctx context.Context, source interface{}, info graphql.ResolveInfo) (interface{}, error) {
+							return source.(*User).Num, nil
+						}),
+					},
+				},
+			}
+
+			complexInputType := &graphql.InputObjectConfig{
+				Name: "Complex",
+				Fields: graphql.InputFields{
+					"userId": {
+						Type: userIDType,
+						DefaultValue: UserID{
+							ID: "5678",
+						},
+					},
+					"userNum": {
+						Type: positiveIntType,
+					},
+				},
+			}
+
+			queryType, err := graphql.NewObject(&graphql.ObjectConfig{
+				Name: "Query",
+				Fields: graphql.Fields{
+					"user": {
+						Type: userType,
+						Args: graphql.ArgumentConfigMap{
+							"id": {
+								Type: userIDType,
+							},
+							"n": {
+								Type: positiveIntType,
+							},
+							"c": {
+								Type: complexInputType,
+							},
+						},
+						Resolver: graphql.FieldResolverFunc(func(ctx context.Context, source interface{}, info graphql.ResolveInfo) (interface{}, error) {
+							userID, ok := info.ArgumentValues().Get("id").(UserID)
+							Expect(ok).Should(BeTrue())
+
+							num, ok := info.ArgumentValues().Get("n").(int)
+							Expect(ok).Should(BeTrue())
+
+							complexValue, ok := info.ArgumentValues().Get("c").(map[string]interface{})
+							Expect(ok).Should(BeTrue())
+
+							var userID2 *UserID
+							if complexValue["userId"] != nil {
+								id2, ok := complexValue["userId"].(UserID)
+								Expect(ok).Should(BeTrue())
+								userID2 = &id2
+							}
+
+							return &User{
+								ID:   userID,
+								ID2:  userID2,
+								Name: "generated",
+								Num:  num,
+							}, nil
+						}),
+					},
+				},
+			})
+
+			Schema, err = graphql.NewSchema(&graphql.SchemaConfig{
+				Query: queryType,
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("represents value class as scalar type", func() {
+			query := `{
+  user(id: "1234", n: 42, c: {userNum: 500}) {
+    id
+    id2
+    name
+    num
+  }
+}`
+
+			Expect(executeQuery(Schema, query)).Should(testutil.SerializeToJSONAs(map[string]interface{}{
+				"data": map[string]interface{}{
+					"user": map[string]interface{}{
+						"id":   "1234",
+						"id2":  "5678",
+						"name": "generated",
+						"num":  42,
+					},
+				},
+			}))
+		})
+
+		It("coerces input types correctly", func() {
+			query := `{
+  user(id: "1234", n: -123, c: {userNum: 5}) {
+    id
+    name
+  }
+}`
+			result := executeQuery(Schema, query)
+			Expect(result.Errors.Errors).Should(ConsistOf(testutil.MatchGraphQLError(
+				testutil.MessageEqual(`Argument "n" has invalid value "-123".`),
+				testutil.LocationEqual(graphql.ErrorLocation{
+					Line:   2,
+					Column: 23,
+				}),
+			)))
+
+			query = `{
+  user(id: "1234", n: 123, c: {userId: 1, userNum: 5}) {
+    id
+    name
+  }
+}`
+			result = executeQuery(Schema, query)
+			Expect(result.Errors.Errors).Should(ConsistOf(testutil.MatchGraphQLError(
+				testutil.MessageContainSubstring(`Argument "c" has invalid value`),
+				testutil.LocationEqual(graphql.ErrorLocation{
+					Line:   2,
+					Column: 31,
+				}),
+			)))
+
+			query = `{
+  user(id: "1234", n: 123, c: {userNum: -5}) {
+    id
+    name
+  }
+}`
+			result = executeQuery(Schema, query)
+			Expect(result.Errors.Errors).Should(ConsistOf(testutil.MatchGraphQLError(
+				testutil.MessageEqual(`Argument "c" has invalid value "map[userNum:-5]".`),
+				testutil.LocationEqual(graphql.ErrorLocation{
+					Line:   2,
+					Column: 31,
+				}),
+			)))
+		})
+	})
+})

--- a/graphql/schema.go
+++ b/graphql/schema.go
@@ -45,6 +45,11 @@ func (typeMap TypeMap) add(t Type) error {
 			continue
 		}
 
+		// For ScalarAlias, we want to add its aliasing Scalar and skip the ScalarAlias.
+		if alias, ok := t.(ScalarAlias); ok {
+			t = alias.AliasFor()
+		}
+
 		// Map type name to corresponding Type.
 		if namedType, ok := t.(TypeWithName); ok {
 			name := namedType.Name()

--- a/graphql/type_creator.go
+++ b/graphql/type_creator.go
@@ -118,6 +118,8 @@ func newCreatorFor(typeDef TypeDefinition) typeCreator {
 	switch typeDef := typeDef.(type) {
 	case ScalarTypeDefinition:
 		return &scalarTypeCreator{typeDef}
+	case ScalarAliasTypeDefinition:
+		return &scalarAliasTypeCreator{typeDef}
 	case EnumTypeDefinition:
 		return &enumTypeCreator{typeDef}
 	case ObjectTypeDefinition:

--- a/graphql/type_definitions.go
+++ b/graphql/type_definitions.go
@@ -145,6 +145,33 @@ type ScalarTypeDefinition interface {
 }
 
 //===-----------------------------------------------------------------------------------------====//
+// ScalarAlias Type Definition
+//===-----------------------------------------------------------------------------------------====//
+
+// ScalarAliasTypeData contains type data for ScalarAlias.
+type ScalarAliasTypeData struct {
+	// The Scalar type being aliased to. Note that we take Scalar instead of ScalarTypeDefinition here
+	// for convenience.
+	AliasFor Scalar
+}
+
+// ScalarAliasTypeDefinition provides data accessors that are required for defining a ScalarAlias.
+type ScalarAliasTypeDefinition interface {
+	TypeDefinition
+
+	// TypeData reads data from the definition for the defining scalar type alias.
+	TypeData() ScalarAliasTypeData
+
+	// NewResultCoercer creates a ScalarAliasResultCoercer instance for the defining ScalarAlias type
+	// object during its initialization.
+	NewResultCoercer(scalar ScalarAlias) (ScalarResultCoercer, error)
+
+	// NewInputCoercer creates an ScalarAliasInputCoercer instance for the defining ScalarAlias type
+	// object during its initialization.
+	NewInputCoercer(scalar ScalarAlias) (ScalarInputCoercer, error)
+}
+
+//===-----------------------------------------------------------------------------------------====//
 // Enum Type Definition
 //===-----------------------------------------------------------------------------------------====//
 

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -209,6 +209,32 @@ func (f ScalarInputCoercerFuncs) CoerceArgumentValue(value ast.Value) (interface
 var _ ScalarInputCoercer = ScalarInputCoercerFuncs{}
 
 //===----------------------------------------------------------------------------------------====//
+// Scalar Alias
+//===----------------------------------------------------------------------------------------====//
+
+// ScalarAlias builds a custom coercion on top of a Scalar type. It looks and works like an ordinary
+// Scalar type. In schema, the type is still represented by the aliasing Scalar but behind the
+// scenes values to these types are coerced in the ways defined by the ScalarAlias types. Typical
+// use cases for ScalarAlias include:
+//
+//  1. Add a validation on top of a Scalar, such as constrain an Int to be positive;
+//
+//  2. Transform into different type of internal value, for example, to use a custom UUID type in Go
+//     for values represented by the built-in ID.
+//
+// The brilliant idea is borrowed from Scalar Type Alias [0] in Sangria [1].
+//
+// [0]: https://sangria-graphql.org/learn/#scalar-type-alias
+// [1]: https://github.com/sangria-graphql/sangria
+type ScalarAlias interface {
+	// A ScalarAlias behaves like the Scalar being aliased to.
+	Scalar
+
+	// AliasFor describes the Scalar that is aliased by this type.
+	AliasFor() Scalar
+}
+
+//===----------------------------------------------------------------------------------------====//
 // Object
 //===----------------------------------------------------------------------------------------====//
 


### PR DESCRIPTION
ScalarAlias can extend Scalars with custom coercion.

See https://sangria-graphql.org/learn/#scalar-type-alias.

Closes #92.