### PR TITLE
[future] Fix Join.

### DIFF
--- a/concurrent/future/join.go
+++ b/concurrent/future/join.go
@@ -16,39 +16,92 @@
 
 package future
 
+import (
+	"sync/atomic"
+)
+
 // join implements Future returned by Join.
 type join struct {
-	inputs  []Future
-	results []interface{}
+	values []interface{}
+	// If one of the value is completed with an error, this will set to the error for return.
+	err   atomic.Value /*error */
+	waker Waker
+	// Number of values currently wait for completing the join
+	pendingCount int64
 }
 
-// Poll implements future.Future.
-func (f *join) Poll(waker Waker) (PollResult, error) {
-	var (
-		done    = true
-		results = f.results
-	)
+// joinPendingValue is created for each future within a join that is waiting for result. It
+// implements Waker interface which re-poll the associated future on notify and if the future
+// completes with a result, update the value to the containing join. Furthermore, if the update
+// clears all pending values in containing join (i.e., j.pendingCount reaches 0), also notify
+// j.waker.
+type joinPendingValue struct {
+	// The join that depends on this value
+	j *join
 
-	for i, input := range f.inputs {
-		if results[i] != PollResultPending {
-			continue
-		}
+	// The future to poll for value
+	f Future
 
-		// Check input future.
-		result, err := input.Poll(waker)
-		if err != nil {
-			return nil, err
-		}
+	// The index of value within containing join
+	i int
+}
 
-		if result == PollResultPending {
-			done = false
-		} else {
-			results[i] = interface{}(result)
+func (value *joinPendingValue) poll() (interface{}, error) {
+	return value.f.Poll(value)
+}
+
+func (value *joinPendingValue) Wake() error {
+	// Poll the future.
+	result, err := value.poll()
+	if err != nil {
+		// Store error and wake the join to return.
+		j := value.j
+		j.err.Store(err)
+		return j.waker.Wake()
+	} else if result != PollResultPending {
+		// The future is completed. Set the result.
+		j := value.j
+		j.values[value.i] = result
+
+		// Decrement pendingCount.
+		if atomic.AddInt64(&j.pendingCount, -1) == 0 {
+			// All values are ready. Notify join's waker.
+			return j.waker.Wake()
 		}
 	}
 
-	if done {
-		return f.results, nil
+	return nil
+}
+
+// Poll implements future.Future.
+func (j *join) Poll(waker Waker) (PollResult, error) {
+	var (
+		done   int64
+		values = j.values
+	)
+
+	if err := j.err.Load(); err != nil {
+		return nil, err.(error)
+	}
+
+	// Update waker.
+	j.waker = waker
+
+	for i, value := range values {
+		if value, ok := value.(*joinPendingValue); ok {
+			// Poll the future for value.
+			result, err := value.poll()
+			if err != nil {
+				return nil, err
+			} else if result != PollResultPending {
+				values[i] = interface{}(result)
+				done++
+			}
+		}
+	}
+
+	if atomic.AddInt64(&j.pendingCount, -done) == 0 {
+		return j.values, nil
 	}
 
 	return PollResultPending, nil
@@ -60,13 +113,20 @@ func (f *join) Poll(waker Waker) (PollResult, error) {
 // []interface{} in the same order as they're given.
 func Join(f ...Future) Future {
 	// Initialize storage for result values.
-	results := make([]interface{}, len(f))
-	for i := range results {
-		results[i] = PollResultPending
+	values := make([]interface{}, len(f))
+	j := &join{
+		values:       values,
+		waker:        NopWaker,
+		pendingCount: int64(len(f)),
 	}
 
-	return &join{
-		inputs:  f,
-		results: results,
+	for i, f := range f {
+		values[i] = &joinPendingValue{
+			j: j,
+			f: f,
+			i: i,
+		}
 	}
+
+	return j
 }

--- a/concurrent/future/join_test.go
+++ b/concurrent/future/join_test.go
@@ -25,6 +25,48 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// completeOnNotify is the future that only completes when Complete or SetErr method is called.
+type completeOnNotify struct {
+	value     interface{}
+	err       error
+	waker     future.Waker
+	completed bool
+	polled    bool
+}
+
+func (f *completeOnNotify) Poll(waker future.Waker) (future.PollResult, error) {
+	if !f.completed {
+		f.waker = waker
+		return future.PollResultPending, nil
+	}
+
+	// Completed future can only be polled once.
+	Expect(f.polled).Should(BeFalse())
+	f.polled = true
+
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	return f.value, nil
+}
+
+func (f *completeOnNotify) Complete(value interface{}) error {
+	Expect(f.completed).Should(BeFalse())
+	f.completed = true
+	f.value = value
+	Expect(f.waker).ShouldNot(BeNil())
+	return f.waker.Wake()
+}
+
+func (f *completeOnNotify) SetErr(err error) error {
+	Expect(f.completed).Should(BeFalse())
+	f.completed = true
+	f.err = err
+	Expect(f.waker).ShouldNot(BeNil())
+	return f.waker.Wake()
+}
+
 var _ = Describe("Join: collect values from multiple futures", func() {
 	It("creates future that contains no underlying futures", func() {
 		f := future.Join([]future.Future{}...)
@@ -49,5 +91,68 @@ var _ = Describe("Join: collect values from multiple futures", func() {
 		)
 		_, err := future.BlockOn(f)
 		Expect(err).Should(MatchError(err))
+	})
+
+	Describe("with more complex future which completes on notify", func() {
+		var f1, f2, f3 *completeOnNotify
+
+		BeforeEach(func() {
+			f1 = &completeOnNotify{}
+			f2 = &completeOnNotify{}
+			f3 = &completeOnNotify{}
+		})
+
+		It("wakes join at most once on its completion", func() {
+			f := future.Join(f1, f2, f3)
+
+			waken := false
+			waker := future.WakerFunc(func() error {
+				Expect(waken).Should(BeFalse())
+				waken = true
+				return nil
+			})
+
+			Expect(f.Poll(waker)).Should(Equal(future.PollResultPending))
+			Expect(waken).Should(BeFalse())
+
+			Expect(f1.Complete(1)).Should(Succeed())
+			Expect(f.Poll(waker)).Should(Equal(future.PollResultPending))
+			Expect(waken).Should(BeFalse())
+
+			Expect(f2.Complete(2)).Should(Succeed())
+			Expect(f.Poll(waker)).Should(Equal(future.PollResultPending))
+			Expect(waken).Should(BeFalse())
+
+			Expect(f3.Complete(3)).Should(Succeed())
+			Expect(f.Poll(waker)).Should(Equal([]interface{}{1, 2, 3}))
+			Expect(waken).Should(BeTrue())
+		})
+
+		It("completes join with error if one of future is completed with an error", func() {
+			f := future.Join(f1, f2, f3)
+
+			waken := false
+			waker := future.WakerFunc(func() error {
+				Expect(waken).Should(BeFalse())
+				waken = true
+				return nil
+			})
+
+			Expect(f.Poll(waker)).Should(Equal(future.PollResultPending))
+			Expect(waken).Should(BeFalse())
+
+			Expect(f1.Complete(1)).Should(Succeed())
+			Expect(f.Poll(waker)).Should(Equal(future.PollResultPending))
+			Expect(waken).Should(BeFalse())
+
+			Expect(f2.Complete(2)).Should(Succeed())
+			Expect(f.Poll(waker)).Should(Equal(future.PollResultPending))
+			Expect(waken).Should(BeFalse())
+
+			Expect(f3.SetErr(errors.New("error"))).Should(Succeed())
+			_, err := f.Poll(waker)
+			Expect(err).Should(MatchError("error"))
+			Expect(waken).Should(BeTrue())
+		})
 	})
 })


### PR DESCRIPTION
We have to create a custom waker to poll each future inside a join. The
waker passed to the future returned by Join must only be called when all
of the passed-in futures complete or one of them returns an error.