### PR TITLE
[dataloader] Rewrite TaskIterator to follow our guidelines for iterator pattern

### DIFF
--- a/dataloader/batch_job.go
+++ b/dataloader/batch_job.go
@@ -38,8 +38,13 @@ func (job *BatchLoadJob) Run() (interface{}, error) {
 	config.BatchLoader.Load(job.ctx, tasks)
 
 	// Make sure that all tasks were completed. If not, complete it with an error.
-	for taskIter, taskEnd := tasks.Begin(), tasks.End(); taskIter != taskEnd; taskIter = taskIter.Next() {
-		task := taskIter.Task
+	taskIter := tasks.Iterator()
+	for {
+		task, done := taskIter.Next()
+		if done {
+			break
+		}
+
 		result := task.loadResult()
 		if result.Kind == taskNotCompleted {
 			task.SetError(fmt.Errorf("%T must complete every given data loading task with either a "+

--- a/dataloader/dataloader.go
+++ b/dataloader/dataloader.go
@@ -281,7 +281,7 @@ func (loader *DataLoader) dispatchQueue(ctx context.Context, queue *taskQueue) {
 			counter   = maxBatchSize
 		)
 
-		for task != nil {
+		for {
 			nextTask := task.next
 
 			counter--
@@ -298,15 +298,19 @@ func (loader *DataLoader) dispatchQueue(ctx context.Context, queue *taskQueue) {
 				firstTask = nextTask
 			}
 
+			// We reach the end of list. Dispatch the last batch.
+			if nextTask == nil {
+				if firstTask != nil {
+					loader.dispatchQueueBatch(ctx, TaskList{
+						first: firstTask,
+						last:  task,
+					})
+				}
+				break
+			}
+
 			// Move to the next task.
 			task = nextTask
-		}
-
-		// Dispatch the last batch.
-		if firstTask != nil {
-			loader.dispatchQueueBatch(ctx, TaskList{
-				first: firstTask,
-			})
 		}
 	}
 }

--- a/dataloader/task.go
+++ b/dataloader/task.go
@@ -271,23 +271,22 @@ func (t *Task) Completed() bool {
 //===----------------------------------------------------------------------------------------====//
 
 // TaskList represents a list of Task's stored in a linked list from begin (included) to the end
-// (excluded). It provides an iterator to access the TaskList in the list.
+// (included). It provides an iterator to access the TaskList in the list.
 type TaskList struct {
 	first *Task
 	last  *Task
 }
 
-// Begin returns an iterator pointing to the first task in the list.
-func (tasks *TaskList) Begin() TaskIterator {
-	return TaskIterator{tasks.first}
-}
-
-// End returns an iterator refers to the pass-to-the-end task in the list.
-func (tasks *TaskList) End() TaskIterator {
-	if tasks.last != nil {
-		return TaskIterator{tasks.last.next}
+// Iterator returns an iterator over tasks in the list.
+func (tasks *TaskList) Iterator() *TaskIterator {
+	if tasks.Empty() {
+		return &TaskIterator{}
 	}
-	return TaskIterator{nil}
+
+	return &TaskIterator{
+		cur: tasks.first,
+		end: tasks.last.next,
+	}
 }
 
 // Empty returns true if the TaskList doesn't contain any tasks.
@@ -311,18 +310,30 @@ func (tasks *TaskList) push(task *Task) {
 //
 // Example:
 //
-//	for taskIter, taskEnd := tasks.Begin(), tasks.End(); taskIter != taskEnd; taskIter = taskIter.Next() {
-//		task := taskIter.Task()
-//		...
+//	taskIter := tasks.Iterator()
+//	for {
+//		task, done := taskIter.Next()
+//		if done {
+//			break
+//		}
+//
+//		... process task ...
 //	}
 type TaskIterator struct {
 	// The referring task by this iterator
-	*Task
+	cur *Task
+	// The pass-to-the-end task
+	end *Task
 }
 
 // Next returns a TaskIterator that refers to the Task next to the one referred by iter in the list.
 // Note that it is an undefined behavior if iter doesn't refer to one of the task in the corresponding
 // TaskList.
-func (iter TaskIterator) Next() TaskIterator {
-	return TaskIterator{iter.Task.next}
+func (iter *TaskIterator) Next() (task *Task, done bool) {
+	cur := iter.cur
+	if cur == iter.end {
+		return nil, true
+	}
+	iter.cur = cur.next
+	return cur, false
 }

--- a/graphql/executor/dataloader_test.go
+++ b/graphql/executor/dataloader_test.go
@@ -98,8 +98,12 @@ func (loader *CharacterBatchLoader) Load(ctx context.Context, tasks *dataloader.
 	// Collect keys for check.
 	var keys []dataloader.Key
 
-	for taskIter, taskEnd := tasks.Begin(), tasks.End(); taskIter != taskEnd; taskIter = taskIter.Next() {
-		task := taskIter.Task
+	taskIter := tasks.Iterator()
+	for {
+		task, done := taskIter.Next()
+		if done {
+			break
+		}
 		key := task.Key()
 		Expect(task.Complete(loader.data[key.(CharacterID)])).Should(Succeed())
 		keys = append(keys, key)


### PR DESCRIPTION
Also fix a bug where `DataLoader.dispatchQueue` doesn't set `last` in
the task list for *remainder batch*.