### PR TITLE
[core] Use map to store possible types of abstract types.

### DIFF
--- a/graphql/executor/execute.go
+++ b/graphql/executor/execute.go
@@ -275,7 +275,7 @@ func findFieldDef(
 func doesTypeConditionSatisfy(
 	ctx *ExecutionContext,
 	typeCondition ast.NamedType,
-	t graphql.Type) bool {
+	t graphql.Object) bool {
 	schema := ctx.Operation().Schema()
 
 	conditionalType := schema.TypeFromAST(typeCondition)
@@ -283,12 +283,9 @@ func doesTypeConditionSatisfy(
 		return true
 	}
 
-	if abstractType, ok := t.(graphql.AbstractType); ok {
-		for _, possibleType := range schema.PossibleTypes(abstractType) {
-			if possibleType == t {
-				return true
-			}
-		}
+	if abstractType, ok := conditionalType.(graphql.AbstractType); ok {
+		possibleTypes := schema.PossibleTypes(abstractType)
+		return possibleTypes.Contains(t)
 	}
 
 	return false

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -306,6 +306,30 @@ func (*ThisIsInterfaceType) graphqlInterfaceType() {}
 // Union
 //===----------------------------------------------------------------------------------------====//
 
+// PossibleTypeSet stores possible types for an abstract type (could be either an Interface or an
+// Union) in a schema.
+type PossibleTypeSet struct {
+	types map[Object]bool
+}
+
+// NewPossibleTypeSet creates an empty PossibleTypeSet.
+func NewPossibleTypeSet() PossibleTypeSet {
+	return PossibleTypeSet{
+		types: map[Object]bool{},
+	}
+}
+
+// Add adds a type to the set.
+func (set PossibleTypeSet) Add(o Object) {
+	set.types[o] = true
+}
+
+// Contains returns true if the given Object type is the possible types of the abstract type
+// associated with the set.
+func (set PossibleTypeSet) Contains(o Object) bool {
+	return set.types[o]
+}
+
 // Union Type Definition
 //
 // When a field can return one of a heterogeneous set of types, a Union type is used to describe
@@ -317,7 +341,7 @@ type Union interface {
 	AbstractType
 
 	// Types returns member of the union type.
-	PossibleTypes() []Object
+	PossibleTypes() PossibleTypeSet
 
 	// graphqlUnionType puts a special mark for an Union type.
 	graphqlUnionType()

--- a/graphql/union.go
+++ b/graphql/union.go
@@ -94,18 +94,15 @@ func (creator *unionTypeCreator) Finalize(t Type, typeDefResolver typeDefinition
 	union.typeResolver = typeResolver
 
 	// Resolve possible object types.
-	numPossibleTypes := len(union.data.PossibleTypes)
-	if numPossibleTypes > 0 {
-		possibleTypes := make([]Object, numPossibleTypes)
-		for i, possibleTypeDef := range union.data.PossibleTypes {
-			possibleType, err := typeDefResolver(possibleTypeDef)
-			if err != nil {
-				return err
-			}
-			possibleTypes[i] = possibleType.(Object)
+	possibleTypes := NewPossibleTypeSet()
+	for _, possibleTypeDef := range union.data.PossibleTypes {
+		possibleType, err := typeDefResolver(possibleTypeDef)
+		if err != nil {
+			return err
 		}
-		union.possibleTypes = possibleTypes
+		possibleTypes.Add(possibleType.(Object))
 	}
+	union.possibleTypes = possibleTypes
 
 	return nil
 }
@@ -115,7 +112,7 @@ func (creator *unionTypeCreator) Finalize(t Type, typeDefResolver typeDefinition
 type union struct {
 	ThisIsUnionType
 	data          UnionTypeData
-	possibleTypes []Object
+	possibleTypes PossibleTypeSet
 	typeResolver  TypeResolver
 }
 
@@ -163,6 +160,6 @@ func (u *union) Description() string {
 }
 
 // PossibleTypes implements Union.
-func (u *union) PossibleTypes() []Object {
+func (u *union) PossibleTypes() PossibleTypeSet {
 	return u.possibleTypes
 }

--- a/graphql/union_test.go
+++ b/graphql/union_test.go
@@ -36,18 +36,20 @@ var _ = Describe("Union", func() {
 	})
 
 	It("accepts empty set of possible types", func() {
+		emptyPossibleSet := graphql.NewPossibleTypeSet()
+
 		unionType, err := graphql.NewUnion(&graphql.UnionConfig{
 			Name:          "UnionWithEmptySetOfPossibleTypes",
 			PossibleTypes: []graphql.ObjectTypeDefinition{},
 		})
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(unionType.PossibleTypes()).Should(BeEmpty())
+		Expect(unionType.PossibleTypes()).Should(Equal(emptyPossibleSet))
 
 		unionType, err = graphql.NewUnion(&graphql.UnionConfig{
 			Name: "UnionWithoutPossibleTypes",
 		})
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(unionType.PossibleTypes()).Should(BeEmpty())
+		Expect(unionType.PossibleTypes()).Should(Equal(emptyPossibleSet))
 	})
 
 	It("rejects creating type without a name", func() {


### PR DESCRIPTION
Add `PossibleTypeSet` which uses `map[Object]bool` to store:

  1. Member types of an Union
  2. Possible types for each `Interface` and `Union` in a `Schema`.

This allows faster tests during execution.

Closes #132.