### PR TITLE
Reinvent wheel for encoding json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,6 @@
 module github.com/botobag/artemis
 
 require (
-	github.com/json-iterator/go v1.1.5
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.6.0
 	github.com/onsi/gomega v1.4.2
 )

--- a/go.sum
+++ b/go.sum
@@ -4,12 +4,6 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/json-iterator/go v1.1.5 h1:gL2yXlmiIo4+t+y32d4WGwOjKGYcGOuyrg46vadswDE=
-github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
-github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
-github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
-github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
-github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/onsi/ginkgo v1.6.0 h1:Ix8l273rp3QzYgXSR+c8d1fTG7UPgYkOSELPhiY/YGw=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.2 h1:3mYCb7aPxS/RU7TI1y4rkEn1oKmPRjNJLNEXgw7MH2I=

--- a/graphql/executor/result_marshaler_benchmark_test.go
+++ b/graphql/executor/result_marshaler_benchmark_test.go
@@ -154,7 +154,7 @@ func BenchmarkMarshalStarWarsFriendsQueryResultToJSONWithGo(b *testing.B) {
 	}
 }
 
-func BenchmarkMarshalStarWarsFriendsQueryResultToJSONWithJsoniter(b *testing.B) {
+func BenchmarkMarshalStarWarsFriendsQueryResultToJSONWithJsonwriter(b *testing.B) {
 	var (
 		buf    bytes.Buffer
 		result = queryStarWarsCharacterFriends(b)

--- a/graphql/inspect.go
+++ b/graphql/inspect.go
@@ -23,8 +23,7 @@ import (
 	"runtime"
 
 	"github.com/botobag/artemis/internal/util"
-
-	"github.com/json-iterator/go"
+	"github.com/botobag/artemis/jsonwriter"
 )
 
 // ValueWithCustomInspect provides custom inspect function to serialize value in Inspect.
@@ -44,7 +43,7 @@ func InspectToBuf(v interface{}, out io.Writer) error {
 	switch value.Kind() {
 	case reflect.String:
 		// graphql-js: JSON.stringify(value)
-		stream := jsoniter.NewStream(jsoniter.ConfigDefault, out, 0)
+		stream := jsonwriter.NewStream(out)
 		stream.WriteString(v.(string))
 		if err := stream.Flush(); err != nil {
 			return err

--- a/jsonwriter/jsonwriter_suite_test.go
+++ b/jsonwriter/jsonwriter_suite_test.go
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2019, The Artemis Authors.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package jsonwriter_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestJSONWriter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Artemis JSON Writer Internal")
+}

--- a/jsonwriter/stream.go
+++ b/jsonwriter/stream.go
@@ -1,0 +1,412 @@
+/**
+ * Copyright (c) 2019, The Artemis Authors.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package jsonwriter
+
+import (
+	"encoding/json"
+	"io"
+	"reflect"
+)
+
+const initialStreamBufSize = 512
+
+// Stream provides functions for writing JSON encoding. Unlike encoding/json, the writes are
+// directly sent to to the output via io.Writer.
+type Stream struct {
+	// Output stream
+	w io.Writer
+
+	// Buffer that sits in front of write to w; Its capacity is initialized to 512 bytes and may grow
+	// indefinitely if there're many write{One,Two,...}Byte{s} calls. This is intended to make
+	// write{One,Two,...}Byte{s} fast which is critical in our micro-benchmark
+	// (see graphql/executor/result_marshaler_benchmark_test.go).
+	buf []byte
+
+	// Buffer for Write{Int64,Uint64,Float32,Float64}
+	scratch [64]byte
+
+	// Go's encoding/json.Encoder for encoding values that cannot be proccessed by this writer.
+	fallbackEncoder *json.Encoder
+
+	// Error occurred during writing
+	err error
+}
+
+// NewStream creates a stream for writing data in JSON encoding.
+func NewStream(w io.Writer) *Stream {
+	return &Stream{
+		w:   w,
+		buf: make([]byte, 0, initialStreamBufSize),
+	}
+}
+
+// Error returns error occurred during use of the stream.
+func (stream *Stream) Error() error {
+	return stream.err
+}
+
+// write is the lowest level that performs writes. It writes the contents given in b into w.
+func (stream *Stream) write(b []byte) {
+	// Discard writes if error already occurred in prior to the write.
+	if stream.err != nil {
+		return
+	}
+
+	buf := stream.buf
+	bufSize := len(buf)
+	if bufSize+len(b) < initialStreamBufSize {
+		buf = buf[:bufSize+len(b)]
+		stream.buf = buf
+		copy(buf[bufSize:], b)
+		return
+	}
+
+	if bufSize > 0 {
+		_, err := stream.w.Write(buf)
+		// Reset buf.
+		stream.buf = buf[:0]
+		if err != nil {
+			stream.err = err
+			return
+		}
+	}
+
+	if len(b) > 0 {
+		if _, err := stream.w.Write(b); err != nil {
+			stream.err = err
+			return
+		}
+	}
+}
+
+// Flush writes any buffered data to the underlying io.Writer.
+func (stream *Stream) Flush() error {
+	if stream.err != nil {
+		return stream.err
+	}
+
+	buf := stream.buf
+	if len(buf) > 0 {
+		_, err := stream.w.Write(buf)
+		// Reset buf.
+		stream.buf = buf[:0]
+		if err != nil {
+			stream.err = err
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (stream *Stream) writeOneByte(b byte) {
+	stream.buf = append(stream.buf, b)
+}
+
+func (stream *Stream) writeTwoBytes(b1 byte, b2 byte) {
+	stream.buf = append(stream.buf, b1, b2)
+}
+
+func (stream *Stream) writeThreeBytes(b1 byte, b2 byte, b3 byte) {
+	stream.buf = append(stream.buf, b1, b2, b3)
+}
+
+func (stream *Stream) writeFourBytes(b1 byte, b2 byte, b3 byte, b4 byte) {
+	stream.buf = append(stream.buf, b1, b2, b3, b4)
+}
+
+func (stream *Stream) writeFiveBytes(b1 byte, b2 byte, b3 byte, b4 byte, b5 byte) {
+	stream.buf = append(stream.buf, b1, b2, b3, b4, b5)
+}
+
+func (stream *Stream) writeSixBytes(b1 byte, b2 byte, b3 byte, b4 byte, b5 byte, b6 byte) {
+	stream.buf = append(stream.buf, b1, b2, b3, b4, b5, b6)
+}
+
+// WriteRawString writes raw string into output.
+func (stream *Stream) WriteRawString(s string) {
+	stream.write([]byte(s))
+}
+
+// WriteMore writes a ",".
+func (stream *Stream) WriteMore() {
+	stream.writeOneByte(',')
+}
+
+// WriteArrayStart writes a "[".
+func (stream *Stream) WriteArrayStart() {
+	stream.writeOneByte('[')
+}
+
+// WriteArrayEnd writes a "]".
+func (stream *Stream) WriteArrayEnd() {
+	stream.writeOneByte(']')
+}
+
+// WriteEmptyArray writes "[]".
+func (stream *Stream) WriteEmptyArray() {
+	stream.writeTwoBytes('[', ']')
+}
+
+// WriteObjectStart writes a "{".
+func (stream *Stream) WriteObjectStart() {
+	stream.writeOneByte('{')
+}
+
+// WriteObjectField writes a "field:".
+func (stream *Stream) WriteObjectField(field string) {
+	stream.WriteString(field)
+	stream.writeOneByte(':')
+}
+
+// WriteObjectEnd writes a "}".
+func (stream *Stream) WriteObjectEnd() {
+	stream.writeOneByte('}')
+}
+
+// WriteEmptyObject writes "{}".
+func (stream *Stream) WriteEmptyObject() {
+	stream.writeTwoBytes('{', '}')
+}
+
+// WriteBool encodes a boolean value.
+func (stream *Stream) WriteBool(b bool) {
+	if b {
+		stream.writeFourBytes('t', 'r', 'u', 'e')
+	} else {
+		stream.writeFiveBytes('f', 'a', 'l', 's', 'e')
+	}
+}
+
+// WriteNil writes "null".
+func (stream *Stream) WriteNil() {
+	stream.writeFourBytes('n', 'u', 'l', 'l')
+}
+
+// streamWriter wraps a Stream into an io.Writer object.
+type streamWriter struct {
+	stream *Stream
+}
+
+func (writer streamWriter) Write(p []byte) (n int, err error) {
+	stream := writer.stream
+	stream.write(p)
+	err = stream.err
+	if err == nil {
+		n = len(p)
+	}
+	return
+}
+
+var jsonMarshalerType = reflect.TypeOf(new(json.Marshaler)).Elem()
+
+// WriteInterface writes an interface value using encoding/json.
+func (stream *Stream) WriteInterface(v interface{}) {
+	if stream.err != nil {
+		return
+	}
+
+	// Fast path with type switch
+	switch v := v.(type) {
+	// Bool
+	case bool:
+		stream.WriteBool(v)
+		return
+	case *bool:
+		if v == nil {
+			stream.WriteNil()
+		} else {
+			stream.WriteBool(*v)
+		}
+
+	// String
+	case string:
+		stream.WriteString(v)
+	case *string:
+		if v == nil {
+			stream.WriteNil()
+		} else {
+			stream.WriteString(*v)
+		}
+
+	// Integer
+	case int:
+		stream.WriteInt(v)
+	case int8:
+		stream.WriteInt8(v)
+	case int16:
+		stream.WriteInt16(v)
+	case int32:
+		stream.WriteInt32(v)
+	case int64:
+		stream.WriteInt64(v)
+	case uint:
+		stream.WriteUint(v)
+	case uint8:
+		stream.WriteUint8(v)
+	case uint16:
+		stream.WriteUint16(v)
+	case uint32:
+		stream.WriteUint32(v)
+	case uint64:
+		stream.WriteUint64(v)
+	case *int:
+		if v == nil {
+			stream.WriteNil()
+		} else {
+			stream.WriteInt(*v)
+		}
+	case *int8:
+		if v == nil {
+			stream.WriteNil()
+		} else {
+			stream.WriteInt8(*v)
+		}
+	case *int16:
+		if v == nil {
+			stream.WriteNil()
+		} else {
+			stream.WriteInt16(*v)
+		}
+	case *int32:
+		if v == nil {
+			stream.WriteNil()
+		} else {
+			stream.WriteInt32(*v)
+		}
+	case *int64:
+		if v == nil {
+			stream.WriteNil()
+		} else {
+			stream.WriteInt64(*v)
+		}
+	case *uint:
+		if v == nil {
+			stream.WriteNil()
+		} else {
+			stream.WriteUint(*v)
+		}
+	case *uint8:
+		if v == nil {
+			stream.WriteNil()
+		} else {
+			stream.WriteUint8(*v)
+		}
+	case *uint16:
+		if v == nil {
+			stream.WriteNil()
+		} else {
+			stream.WriteUint16(*v)
+		}
+	case *uint32:
+		if v == nil {
+			stream.WriteNil()
+		} else {
+			stream.WriteUint32(*v)
+		}
+	case *uint64:
+		if v == nil {
+			stream.WriteNil()
+		} else {
+			stream.WriteUint64(*v)
+		}
+
+	// Floating point
+	case float32:
+		stream.WriteFloat32(v)
+	case float64:
+		stream.WriteFloat64(v)
+	case *float32:
+		if v == nil {
+			stream.WriteNil()
+		} else {
+			stream.WriteFloat32(*v)
+		}
+	case *float64:
+		if v == nil {
+			stream.WriteNil()
+		} else {
+			stream.WriteFloat64(*v)
+		}
+
+	case ValueMarshaler:
+		stream.WriteValue(v)
+
+	case nil:
+		stream.WriteNil()
+
+	default:
+		// Fast path using reflection to inspect value type
+		value := reflect.ValueOf(v)
+
+		if value.Type().Implements(jsonMarshalerType) {
+			// If value implements json.Marshaler, go to fallback path and let encoding/json handle it.
+			stream.writeInterfaceFallback(v)
+			return
+		}
+
+		switch value.Kind() {
+		case reflect.Invalid:
+			stream.WriteNil()
+
+		case reflect.Bool:
+			stream.WriteBool(value.Bool())
+
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			stream.WriteInt64(value.Int())
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			stream.WriteUint64(value.Uint())
+
+		case reflect.Float32:
+			stream.WriteFloat32(float32(value.Float()))
+		case reflect.Float64:
+			stream.WriteFloat64(value.Float())
+
+		case reflect.String:
+			stream.WriteString(value.String())
+
+		case reflect.Ptr:
+			elemValue := value.Elem()
+			if !elemValue.IsValid() {
+				// A nil pointer
+				stream.WriteNil()
+			} else {
+				stream.WriteInterface(elemValue.Interface())
+			}
+
+		default:
+			// Fallback to encoding/json to encode value.
+			stream.writeInterfaceFallback(v)
+		}
+	}
+}
+
+// writeInterfaceFallback is the fallback for WriteInterface which encodes the value using
+// encoding/json.
+func (stream *Stream) writeInterfaceFallback(v interface{}) {
+	encoder := stream.fallbackEncoder
+	if encoder == nil {
+		encoder = json.NewEncoder(streamWriter{stream})
+		stream.fallbackEncoder = encoder
+	}
+
+	if err := encoder.Encode(v); err != nil {
+		if stream.err == nil {
+			stream.err = err
+		}
+	}
+}

--- a/jsonwriter/stream_float.go
+++ b/jsonwriter/stream_float.go
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2019, The Artemis Authors.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package jsonwriter
+
+import (
+	"encoding/json"
+	"math"
+	"reflect"
+	"strconv"
+)
+
+// WriteFloat32 writes a float32.
+//
+// Implementation mirrored from https://go.googlesource.com/go/+/5fae09b/src/encoding/json/encode.go#546.
+func (stream *Stream) WriteFloat32(f float32) {
+	if stream.err != nil {
+		return
+	}
+
+	f64 := float64(f)
+	if math.IsInf(f64, 0) || math.IsNaN(f64) {
+		stream.err = &json.UnsupportedValueError{
+			Value: reflect.ValueOf(f),
+			Str:   strconv.FormatFloat(f64, 'g', -1, 32),
+		}
+		return
+	}
+
+	abs := math.Abs(f64)
+	fmt := byte('f')
+	// Note: Must use float32 comparisons for underlying float32 value to get precise cutoffs right.
+	if abs != 0 {
+		if float32(abs) < 1e-6 || float32(abs) >= 1e21 {
+			fmt = 'e'
+		}
+	}
+
+	b := strconv.AppendFloat(stream.scratch[:0], f64, fmt, -1, 32)
+	if fmt == 'e' {
+		// clean up e-09 to e-9
+		n := len(b)
+		if n >= 4 && b[n-4] == 'e' && b[n-3] == '-' && b[n-2] == '0' {
+			b[n-2] = b[n-1]
+			b = b[:n-1]
+		}
+	}
+
+	stream.write(b)
+}
+
+// WriteFloat64 writes a float64.
+//
+// Implementation mirrored from https://go.googlesource.com/go/+/5fae09b/src/encoding/json/encode.go#546.
+func (stream *Stream) WriteFloat64(f float64) {
+	if stream.err != nil {
+		return
+	}
+
+	if math.IsInf(f, 0) || math.IsNaN(f) {
+		stream.err = &json.UnsupportedValueError{
+			Value: reflect.ValueOf(f),
+			Str:   strconv.FormatFloat(f, 'g', -1, 64),
+		}
+		return
+	}
+
+	abs := math.Abs(f)
+	fmt := byte('f')
+	if abs != 0 {
+		if abs < 1e-6 || abs >= 1e21 {
+			fmt = 'e'
+		}
+	}
+
+	b := strconv.AppendFloat(stream.scratch[:0], f, fmt, -1, 64)
+	if fmt == 'e' {
+		// clean up e-09 to e-9
+		n := len(b)
+		if n >= 4 && b[n-4] == 'e' && b[n-3] == '-' && b[n-2] == '0' {
+			b[n-2] = b[n-1]
+			b = b[:n-1]
+		}
+	}
+
+	stream.write(b)
+}

--- a/jsonwriter/stream_int.go
+++ b/jsonwriter/stream_int.go
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2019, The Artemis Authors.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package jsonwriter
+
+import (
+	"strconv"
+)
+
+// WriteInt writes an int.
+func (stream *Stream) WriteInt(i int) {
+	stream.WriteInt64(int64(i))
+}
+
+// WriteInt8 writes an int8.
+func (stream *Stream) WriteInt8(i int8) {
+	stream.WriteInt64(int64(i))
+}
+
+// WriteInt16 writes an int16.
+func (stream *Stream) WriteInt16(i int16) {
+	stream.WriteInt64(int64(i))
+}
+
+// WriteInt32 writes an int32.
+func (stream *Stream) WriteInt32(i int32) {
+	stream.WriteInt64(int64(i))
+}
+
+// WriteInt64 writes an int64.
+func (stream *Stream) WriteInt64(i int64) {
+	stream.write(strconv.AppendInt(stream.scratch[:0], i, 10))
+}
+
+// WriteUint writes an int.
+func (stream *Stream) WriteUint(i uint) {
+	stream.WriteUint64(uint64(i))
+}
+
+// WriteUint8 writes an int8.
+func (stream *Stream) WriteUint8(i uint8) {
+	stream.WriteUint64(uint64(i))
+}
+
+// WriteUint16 writes an int16.
+func (stream *Stream) WriteUint16(i uint16) {
+	stream.WriteUint64(uint64(i))
+}
+
+// WriteUint32 writes an int32.
+func (stream *Stream) WriteUint32(i uint32) {
+	stream.WriteUint64(uint64(i))
+}
+
+// WriteUint64 writes an int64.
+func (stream *Stream) WriteUint64(i uint64) {
+	stream.write(strconv.AppendUint(stream.scratch[:0], i, 10))
+}

--- a/jsonwriter/stream_string.go
+++ b/jsonwriter/stream_string.go
@@ -1,0 +1,386 @@
+/**
+ * Copyright (c) 2019, The Artemis Authors.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package jsonwriter
+
+import (
+	"unicode/utf8"
+)
+
+// This file contains codes derived from Go's encoding/json and json-iterator:
+//
+//  https://go.googlesource.com/go/+/5fae09b/src/encoding/json/tables.go
+//  https://github.com/json-iterator/go/blob/5bc9320/stream_str.go
+//
+// The licenses are reproduced as follows:
+//
+// Go License
+// ==========
+//
+// Copyright (c) 2009 The Go Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//
+// json-iterator License
+// =====================
+//
+// MIT License
+//
+// Copyright (c) 2016 json-iterator
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// safeSet holds the value true if the ASCII character with the given array
+// position can be represented inside a JSON string without any further
+// escaping.
+//
+// All values are true except for the ASCII control characters (0-31), the
+// double quote ("), and the backslash character ("\").
+var safeSet = [utf8.RuneSelf]bool{
+	' ':      true,
+	'!':      true,
+	'"':      false,
+	'#':      true,
+	'$':      true,
+	'%':      true,
+	'&':      true,
+	'\'':     true,
+	'(':      true,
+	')':      true,
+	'*':      true,
+	'+':      true,
+	',':      true,
+	'-':      true,
+	'.':      true,
+	'/':      true,
+	'0':      true,
+	'1':      true,
+	'2':      true,
+	'3':      true,
+	'4':      true,
+	'5':      true,
+	'6':      true,
+	'7':      true,
+	'8':      true,
+	'9':      true,
+	':':      true,
+	';':      true,
+	'<':      true,
+	'=':      true,
+	'>':      true,
+	'?':      true,
+	'@':      true,
+	'A':      true,
+	'B':      true,
+	'C':      true,
+	'D':      true,
+	'E':      true,
+	'F':      true,
+	'G':      true,
+	'H':      true,
+	'I':      true,
+	'J':      true,
+	'K':      true,
+	'L':      true,
+	'M':      true,
+	'N':      true,
+	'O':      true,
+	'P':      true,
+	'Q':      true,
+	'R':      true,
+	'S':      true,
+	'T':      true,
+	'U':      true,
+	'V':      true,
+	'W':      true,
+	'X':      true,
+	'Y':      true,
+	'Z':      true,
+	'[':      true,
+	'\\':     false,
+	']':      true,
+	'^':      true,
+	'_':      true,
+	'`':      true,
+	'a':      true,
+	'b':      true,
+	'c':      true,
+	'd':      true,
+	'e':      true,
+	'f':      true,
+	'g':      true,
+	'h':      true,
+	'i':      true,
+	'j':      true,
+	'k':      true,
+	'l':      true,
+	'm':      true,
+	'n':      true,
+	'o':      true,
+	'p':      true,
+	'q':      true,
+	'r':      true,
+	's':      true,
+	't':      true,
+	'u':      true,
+	'v':      true,
+	'w':      true,
+	'x':      true,
+	'y':      true,
+	'z':      true,
+	'{':      true,
+	'|':      true,
+	'}':      true,
+	'~':      true,
+	'\u007f': true,
+}
+
+// htmlSafeSet holds the value true if the ASCII character with the given
+// array position can be safely represented inside a JSON string, embedded
+// inside of HTML <script> tags, without any additional escaping.
+//
+// All values are true except for the ASCII control characters (0-31), the
+// double quote ("), the backslash character ("\"), HTML opening and closing
+// tags ("<" and ">"), and the ampersand ("&").
+var htmlSafeSet = [utf8.RuneSelf]bool{
+	' ':      true,
+	'!':      true,
+	'"':      false,
+	'#':      true,
+	'$':      true,
+	'%':      true,
+	'&':      false,
+	'\'':     true,
+	'(':      true,
+	')':      true,
+	'*':      true,
+	'+':      true,
+	',':      true,
+	'-':      true,
+	'.':      true,
+	'/':      true,
+	'0':      true,
+	'1':      true,
+	'2':      true,
+	'3':      true,
+	'4':      true,
+	'5':      true,
+	'6':      true,
+	'7':      true,
+	'8':      true,
+	'9':      true,
+	':':      true,
+	';':      true,
+	'<':      false,
+	'=':      true,
+	'>':      false,
+	'?':      true,
+	'@':      true,
+	'A':      true,
+	'B':      true,
+	'C':      true,
+	'D':      true,
+	'E':      true,
+	'F':      true,
+	'G':      true,
+	'H':      true,
+	'I':      true,
+	'J':      true,
+	'K':      true,
+	'L':      true,
+	'M':      true,
+	'N':      true,
+	'O':      true,
+	'P':      true,
+	'Q':      true,
+	'R':      true,
+	'S':      true,
+	'T':      true,
+	'U':      true,
+	'V':      true,
+	'W':      true,
+	'X':      true,
+	'Y':      true,
+	'Z':      true,
+	'[':      true,
+	'\\':     false,
+	']':      true,
+	'^':      true,
+	'_':      true,
+	'`':      true,
+	'a':      true,
+	'b':      true,
+	'c':      true,
+	'd':      true,
+	'e':      true,
+	'f':      true,
+	'g':      true,
+	'h':      true,
+	'i':      true,
+	'j':      true,
+	'k':      true,
+	'l':      true,
+	'm':      true,
+	'n':      true,
+	'o':      true,
+	'p':      true,
+	'q':      true,
+	'r':      true,
+	's':      true,
+	't':      true,
+	'u':      true,
+	'v':      true,
+	'w':      true,
+	'x':      true,
+	'y':      true,
+	'z':      true,
+	'{':      true,
+	'|':      true,
+	'}':      true,
+	'~':      true,
+	'\u007f': true,
+}
+
+var hex = "0123456789abcdef"
+
+// WriteString write string to stream with html special characters escaped
+func (stream *Stream) WriteString(s string) {
+	valLen := len(s)
+	stream.writeOneByte('"')
+	// write string, the fast path, without utf8 and escape support
+	i := 0
+	for ; i < valLen; i++ {
+		c := s[i]
+		if c < utf8.RuneSelf && htmlSafeSet[c] {
+			stream.writeOneByte(byte(c))
+		} else {
+			break
+		}
+	}
+	if i == valLen {
+		stream.writeOneByte('"')
+		return
+	}
+	writeStringSlowPath(stream, i, s, valLen)
+}
+
+func writeStringSlowPath(stream *Stream, i int, s string, valLen int) {
+	start := i
+	// for the remaining parts, we process them char by char
+	for i < valLen {
+		if b := s[i]; b < utf8.RuneSelf {
+			if htmlSafeSet[b] {
+				i++
+				continue
+			}
+			if start < i {
+				stream.WriteRawString(s[start:i])
+			}
+			switch b {
+			case '\\', '"':
+				stream.writeTwoBytes('\\', b)
+			case '\n':
+				stream.writeTwoBytes('\\', 'n')
+			case '\r':
+				stream.writeTwoBytes('\\', 'r')
+			case '\t':
+				stream.writeTwoBytes('\\', 't')
+			default:
+				// This encodes bytes < 0x20 except for \t, \n and \r.
+				// If escapeHTML is set, it also escapes <, >, and &
+				// because they can lead to security holes when
+				// user-controlled strings are rendered into JSON
+				// and served to some browsers.
+				stream.writeSixBytes('\\', 'u', '0', '0', hex[b>>4], hex[b&0xF])
+			}
+			i++
+			start = i
+			continue
+		}
+		c, size := utf8.DecodeRuneInString(s[i:])
+		if c == utf8.RuneError && size == 1 {
+			if start < i {
+				stream.WriteRawString(s[start:i])
+			}
+			stream.writeSixBytes('\\', 'u', 'f', 'f', 'f', 'd')
+			i++
+			start = i
+			continue
+		}
+		// U+2028 is LINE SEPARATOR.
+		// U+2029 is PARAGRAPH SEPARATOR.
+		// They are both technically valid characters in JSON strings,
+		// but don't work in JSONP, which has to be evaluated as JavaScript,
+		// and can lead to security holes there. It is valid JSON to
+		// escape them, so we do so unconditionally.
+		// See http://timelessrepo.com/json-isnt-a-javascript-subset for discussion.
+		if c == '\u2028' || c == '\u2029' {
+			if start < i {
+				stream.WriteRawString(s[start:i])
+			}
+			stream.writeSixBytes('\\', 'u', '2', '0', '2', hex[c&0xF])
+			i += size
+			start = i
+			continue
+		}
+		i += size
+	}
+	if start < len(s) {
+		stream.WriteRawString(s[start:])
+	}
+	stream.writeOneByte('"')
+}

--- a/jsonwriter/stream_test.go
+++ b/jsonwriter/stream_test.go
@@ -1,0 +1,530 @@
+/**
+ * Copyright (c) 2019, The Artemis Authors.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package jsonwriter_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"unicode"
+
+	"github.com/botobag/artemis/internal/util"
+	"github.com/botobag/artemis/jsonwriter"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func typeSwitchEncode(stream *jsonwriter.Stream, value interface{}) {
+	switch value := value.(type) {
+	case map[string]interface{}:
+		if len(value) == 0 {
+			stream.WriteEmptyObject()
+		} else {
+			first := true
+			stream.WriteObjectStart()
+			for k, v := range value {
+				if first {
+					first = false
+				} else {
+					stream.WriteMore()
+				}
+				stream.WriteObjectField(k)
+				typeSwitchEncode(stream, v)
+			}
+			stream.WriteObjectEnd()
+		}
+
+	case []interface{}:
+		if len(value) == 0 {
+			stream.WriteEmptyArray()
+		} else {
+			stream.WriteArrayStart()
+			typeSwitchEncode(stream, value[0])
+			for i := 1; i < len(value); i++ {
+				stream.WriteMore()
+				typeSwitchEncode(stream, value[i])
+			}
+			stream.WriteArrayEnd()
+		}
+
+	default:
+		stream.WriteInterface(value)
+	}
+}
+
+func testStreamWithExpected(value interface{}, expected string) {
+	var (
+		buf    util.StringBuilder
+		stream = jsonwriter.NewStream(&buf)
+	)
+
+	typeSwitchEncode(stream, value)
+
+	// Check output.
+	Expect(stream.Flush()).ShouldNot(HaveOccurred())
+	Expect(buf.String()).Should(MatchJSON(expected), "value = %+v", value)
+}
+
+func testStream(value interface{}) {
+	// Compare output with the one from encoding/json.Marshal.
+	expected, err := json.Marshal(value)
+	Expect(err).ShouldNot(HaveOccurred())
+	testStreamWithExpected(value, string(expected))
+}
+
+type (
+	BoolAlias    bool
+	IntAlias     int
+	Int8Alias    int8
+	Int16Alias   int16
+	Int32Alias   int32
+	Int64Alias   int64
+	UintAlias    uint
+	Uint8Alias   uint8
+	Uint16Alias  uint16
+	Uint32Alias  uint32
+	Uint64Alias  uint64
+	Float32Alias float32
+	Float64Alias float64
+	StringAlias  string
+)
+
+// https://go.googlesource.com/go/+/5fae09b/src/encoding/json/example_marshaling_test.go
+type Animal int
+
+const (
+	Gopher Animal = iota
+	Zebra
+)
+
+func (a Animal) MarshalJSONTo(stream *jsonwriter.Stream) error {
+	switch a {
+	case Gopher:
+		stream.WriteString("gopher")
+	case Zebra:
+		stream.WriteString("zebra")
+	default:
+		return fmt.Errorf("unknown animal: %d", a)
+	}
+	return nil
+}
+
+type NilMarshaler struct{}
+
+func (*NilMarshaler) MarshalJSONTo(stream *jsonwriter.Stream) error {
+	panic("unreachable")
+}
+
+// MarshalJSON implements encoding/json.Marshaler.
+func (a Animal) MarshalJSON() ([]byte, error) {
+	return jsonwriter.Marshal(a)
+}
+
+type GoJSONMarshaler struct {
+	b   []byte
+	err error
+}
+
+func (marshaler *GoJSONMarshaler) MarshalJSON() ([]byte, error) {
+	return marshaler.b, marshaler.err
+}
+
+var _ = Describe("Stream", func() {
+	It("encodes simple but special string with single byte", func() {
+		// Tests from https://go.googlesource.com/go/+/5fae09b/src/encoding/json/encode_test.go.
+		var encodeStringTests = []struct {
+			in  string
+			out string
+		}{
+			{"\x00", `"\u0000"`},
+			{"\x01", `"\u0001"`},
+			{"\x02", `"\u0002"`},
+			{"\x03", `"\u0003"`},
+			{"\x04", `"\u0004"`},
+			{"\x05", `"\u0005"`},
+			{"\x06", `"\u0006"`},
+			{"\x07", `"\u0007"`},
+			{"\x08", `"\u0008"`},
+			{"\x09", `"\t"`},
+			{"\x0a", `"\n"`},
+			{"\x0b", `"\u000b"`},
+			{"\x0c", `"\u000c"`},
+			{"\x0d", `"\r"`},
+			{"\x0e", `"\u000e"`},
+			{"\x0f", `"\u000f"`},
+			{"\x10", `"\u0010"`},
+			{"\x11", `"\u0011"`},
+			{"\x12", `"\u0012"`},
+			{"\x13", `"\u0013"`},
+			{"\x14", `"\u0014"`},
+			{"\x15", `"\u0015"`},
+			{"\x16", `"\u0016"`},
+			{"\x17", `"\u0017"`},
+			{"\x18", `"\u0018"`},
+			{"\x19", `"\u0019"`},
+			{"\x1a", `"\u001a"`},
+			{"\x1b", `"\u001b"`},
+			{"\x1c", `"\u001c"`},
+			{"\x1d", `"\u001d"`},
+			{"\x1e", `"\u001e"`},
+			{"\x1f", `"\u001f"`},
+			{"\x22", `"\""`},
+			{"\x27", `"'"`},
+		}
+
+		for _, tt := range encodeStringTests {
+			testStreamWithExpected(tt.in, tt.out)
+		}
+	})
+
+	It("encodes nil", func() {
+		testStream(nil)
+	})
+
+	It("encodes integers", func() {
+		testStream(int8(math.MaxInt8))
+		testStream(int8(math.MinInt8))
+		testStream(int16(math.MaxInt16))
+		testStream(int16(math.MinInt16))
+		testStream(int32(math.MaxInt32))
+		testStream(int32(math.MinInt32))
+		testStream(int64(math.MaxInt64))
+		testStream(int64(math.MinInt64))
+
+		testStream(uint8(math.MaxUint8))
+		testStream(uint16(math.MaxUint16))
+		testStream(uint32(math.MaxUint32))
+		testStream(uint64(math.MaxUint64))
+
+		testStream(uint8(0))
+		testStream(uint16(0))
+		testStream(uint32(0))
+		testStream(uint64(0))
+
+		// https://groups.google.com/forum/#!msg/golang-nuts/a9PitPAHSSU/ziQw1-QHw3EJ
+		const MaxUint = ^uint(0)
+		const MinUint = 0
+		const MaxInt = int(MaxUint >> 1)
+		const MinInt = -MaxInt - 1
+
+		testStream(int(MaxInt))
+		testStream(int(MinInt))
+		testStream(uint(MaxUint))
+		testStream(uint(MinUint))
+
+		testStream(IntAlias(-1))
+		testStream(Int8Alias(-12))
+		testStream(Int16Alias(-123))
+		testStream(Int32Alias(-1234))
+		testStream(Int64Alias(-12345))
+
+		testStream(UintAlias(1))
+		testStream(Uint8Alias(12))
+		testStream(Uint16Alias(123))
+		testStream(Uint32Alias(1234))
+		testStream(Uint64Alias(12345))
+	})
+
+	It("encodes floats", func() {
+		testStream(float32(0.1))
+		testStream(float64(0.1))
+		testStream(float32(3.14))
+		testStream(float64(3.14))
+		testStream(float32(1e-9))
+		testStream(float64(1e-9))
+
+		testStream(float32(math.MaxFloat32))
+		testStream(float32(math.SmallestNonzeroFloat32))
+
+		testStream(float64(math.MaxFloat64))
+		testStream(float64(math.SmallestNonzeroFloat64))
+
+		testStream(Float32Alias(math.E))
+		testStream(Float64Alias(math.Pi))
+	})
+
+	It("encodes string-like type", func() {
+		testStream(StringAlias("hello"))
+	})
+
+	It("encodes pointers", func() {
+		testStream((*bool)(nil))
+		testStream((*int)(nil))
+		testStream((*int8)(nil))
+		testStream((*int16)(nil))
+		testStream((*int32)(nil))
+		testStream((*int64)(nil))
+		testStream((*uint)(nil))
+		testStream((*uint8)(nil))
+		testStream((*uint16)(nil))
+		testStream((*uint32)(nil))
+		testStream((*uint64)(nil))
+		testStream((*float32)(nil))
+		testStream((*float64)(nil))
+		testStream((*string)(nil))
+
+		testStream((*BoolAlias)(nil))
+		testStream((*IntAlias)(nil))
+		testStream((*Int8Alias)(nil))
+		testStream((*Int16Alias)(nil))
+		testStream((*Int32Alias)(nil))
+		testStream((*Int64Alias)(nil))
+		testStream((*UintAlias)(nil))
+		testStream((*Uint8Alias)(nil))
+		testStream((*Uint16Alias)(nil))
+		testStream((*Uint32Alias)(nil))
+		testStream((*Uint64Alias)(nil))
+		testStream((*Float32Alias)(nil))
+		testStream((*Float64Alias)(nil))
+		testStream((*StringAlias)(nil))
+
+		var (
+			b   bool
+			i   int
+			i8  int8
+			i16 int16
+			i32 int32
+			i64 int64
+			u   uint
+			u8  uint8
+			u16 uint16
+			u32 uint32
+			u64 uint64
+			s   string
+			f32 float32
+			f64 float64
+		)
+
+		testStream(&b)
+		testStream(&i)
+		testStream(&i8)
+		testStream(&i16)
+		testStream(&i32)
+		testStream(&i64)
+		testStream(&u)
+		testStream(&u8)
+		testStream(&u16)
+		testStream(&u32)
+		testStream(&u64)
+		testStream(&s)
+		testStream(&f32)
+		testStream(&f64)
+
+		var (
+			bAlias   BoolAlias
+			iAlias   IntAlias
+			i8Alias  Int8Alias
+			i16Alias Int16Alias
+			i32Alias Int32Alias
+			i64Alias Int64Alias
+			uAlias   UintAlias
+			u8Alias  Uint8Alias
+			u16Alias Uint16Alias
+			u32Alias Uint32Alias
+			u64Alias Uint64Alias
+			sAlias   StringAlias
+			f32Alias Float32Alias
+			f64Alias Float64Alias
+		)
+
+		testStream(&bAlias)
+		testStream(&iAlias)
+		testStream(&i8Alias)
+		testStream(&i16Alias)
+		testStream(&i32Alias)
+		testStream(&i64Alias)
+		testStream(&uAlias)
+		testStream(&u8Alias)
+		testStream(&u16Alias)
+		testStream(&u32Alias)
+		testStream(&u64Alias)
+		testStream(&sAlias)
+		testStream(&f32Alias)
+		testStream(&f64Alias)
+	})
+
+	It("encodes arrays", func() {
+		// Empty array
+		testStream([]interface{}{})
+
+		testStream([]interface{}{
+			"a",
+			1,
+			"c",
+			nil,
+		})
+	})
+
+	It("encodes object", func() {
+		// Empty object
+		testStream(map[string]interface{}{})
+
+		testStream(map[string]interface{}{
+			"K": "Kelvin",
+			"ß": "long s",
+		})
+	})
+
+	It("encodes bool", func() {
+		testStream(true)
+		testStream(false)
+		testStream(BoolAlias(true))
+		testStream(BoolAlias(false))
+	})
+
+	It("escapes HTML characters", func() {
+		// https://go.googlesource.com/go/+/5fae09b/src/encoding/json/encode_test.go#635
+		testStreamWithExpected(
+			`<html>foo &`+"\xe2\x80\xa8 \xe2\x80\xa9"+`</html>`,
+			`"\u003chtml\u003efoo \u0026\u2028 \u2029\u003c/html\u003e"`,
+		)
+	})
+
+	It("encodes value that implements json.Marshaler", func() {
+		testStream(&GoJSONMarshaler{
+			b: []byte{'"', 'h', 'e', 'l', 'l', 'o', '"'},
+		})
+
+		stream := jsonwriter.NewStream(&util.StringBuilder{})
+		stream.WriteInterface(&GoJSONMarshaler{
+			err: errors.New("test marshaler error"),
+		})
+
+		err := stream.Flush()
+		Expect(err).Should(HaveOccurred())
+		Expect(err.Error()).Should(ContainSubstring("test marshaler error"))
+	})
+
+	It("accepts invalid utf8", func() {
+		var r []rune
+		for i := '\u0000'; i <= unicode.MaxRune; i++ {
+			r = append(r, i)
+		}
+		s := string(r) + "\xff\xff\xffhello" // some invalid UTF-8 too
+		testStream(s)
+	})
+
+	It("encodes arbitrary types with encoding.json", func() {
+		// https://go.googlesource.com/go/+/5fae09b/src/encoding/json/encode_test.go#58
+		type Optionals struct {
+			Sr  string                 `json:"sr"`
+			So  string                 `json:"so,omitempty"`
+			Sw  string                 `json:"-"`
+			Ir  int                    `json:"omitempty"` // actually named omitempty, not an option
+			Io  int                    `json:"io,omitempty"`
+			Slr []string               `json:"slr,random"`
+			Slo []string               `json:"slo,omitempty"`
+			Mr  map[string]interface{} `json:"mr"`
+			Mo  map[string]interface{} `json:",omitempty"`
+			Fr  float64                `json:"fr"`
+			Fo  float64                `json:"fo,omitempty"`
+			Br  bool                   `json:"br"`
+			Bo  bool                   `json:"bo,omitempty"`
+			Ur  uint                   `json:"ur"`
+			Uo  uint                   `json:"uo,omitempty"`
+			Str struct{}               `json:"str"`
+			Sto struct{}               `json:"sto,omitempty"`
+		}
+
+		const optionalsExpected = `{
+ "sr": "",
+ "omitempty": 0,
+ "slr": null,
+ "mr": {},
+ "fr": 0,
+ "br": false,
+ "ur": 0,
+ "str": {},
+ "sto": {}
+}`
+
+		var o Optionals
+		o.Sw = "something"
+		o.Mr = map[string]interface{}{}
+		o.Mo = map[string]interface{}{}
+
+		testStreamWithExpected(o, strings.Map(func(r rune) rune {
+			if unicode.IsSpace(r) {
+				return -1
+			}
+			return r
+		}, optionalsExpected))
+	})
+
+	It("fails to encode unsupported values", func() {
+		// https://go.googlesource.com/go/+/5fae09b/src/encoding/json/encode_test.go#137
+		var unsupportedValues = []interface{}{
+			math.NaN(),
+			math.Inf(-1),
+			math.Inf(1),
+			float32(math.NaN()),
+			float32(math.Inf(-1)),
+			float32(math.Inf(1)),
+		}
+
+		for _, v := range unsupportedValues {
+			stream := jsonwriter.NewStream(&util.StringBuilder{})
+			stream.WriteInterface(v)
+			Expect(stream.Flush()).Should(HaveOccurred(), "value: %+v, type: %T", v, v)
+		}
+	})
+
+	Context("encodes values that implements custom marshaler", func() {
+		It("simple values", func() {
+			// https://go.googlesource.com/go/+/5fae09b/src/encoding/json/example_marshaling_test.go
+			zoo := []interface{}{
+				Gopher,
+				Zebra,
+				Gopher,
+				Gopher,
+				Zebra,
+			}
+			testStream(zoo)
+		})
+
+		It("encodes to null", func() {
+			var nilMarshaler *NilMarshaler
+			testStreamWithExpected(nilMarshaler, "null")
+		})
+
+		It("returns error when custom marshaler failed", func() {
+			var (
+				zoo = []interface{}{
+					Gopher,
+					Animal(123),
+					Zebra,
+					Gopher,
+					Gopher,
+					Zebra,
+				}
+				stream = jsonwriter.NewStream(&util.StringBuilder{})
+			)
+
+			typeSwitchEncode(stream, zoo)
+			Expect(stream.Flush()).ShouldNot(Succeed())
+
+			streamErr := stream.Error()
+			Expect(streamErr.Error()).Should(ContainSubstring("unknown animal: 123"))
+
+			_, err := json.Marshal(zoo)
+			Expect(err).Should(MatchError(streamErr))
+		})
+	})
+})

--- a/jsonwriter/value_marshaler.go
+++ b/jsonwriter/value_marshaler.go
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2019, The Artemis Authors.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package jsonwriter
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+)
+
+// ValueMarshaler is the interface implemented by types that can marshal themselves to JSON into a stream.
+type ValueMarshaler interface {
+	MarshalJSONTo(stream *Stream) error
+}
+
+// WriteValue writes a value that implements ValueMarshaler.
+func (stream *Stream) WriteValue(marshaller ValueMarshaler) {
+	if stream.err != nil {
+		// Quick return if stream is erroneous.
+		return
+	}
+
+	// Handle null pointers like encoding/json.marshalerEncoder [0].
+	//
+	// [0]: https://go.googlesource.com/go/+/5fae09b/src/encoding/json/encode.go#445.
+	value := reflect.ValueOf(marshaller)
+	if value.Kind() == reflect.Ptr && value.IsNil() {
+		stream.WriteNil()
+		return
+	}
+
+	if err := marshaller.MarshalJSONTo(stream); err != nil {
+		// Preserve the previous error.
+		if stream.err == nil {
+			stream.err = &json.MarshalerError{
+				Type: value.Type(),
+				Err:  err,
+			}
+		}
+	}
+}
+
+// Marshal returns the JSON encoding of v that implements ValueMarshaler. It is useful for
+// implements type's MarshalJSON to adapt encoding/json Marshaler API.
+func Marshal(v ValueMarshaler) ([]byte, error) {
+	// We choose to implement a simplified version of WriteValue instead of calling WriteValue for the
+	// following reasons:
+	//
+	//  1. We don't need to check stream.err at the beginning of marshaling.
+	//  2. We don't want the error to be wrapped in a json.MarshalerError. Let encoding/json do this
+	//     for us.
+
+	// Handle null pointers like encoding/json.marshalerEncoder [0].
+	//
+	// [0]: https://go.googlesource.com/go/+/5fae09b/src/encoding/json/encode.go#445.
+	value := reflect.ValueOf(v)
+	if value.Kind() == reflect.Ptr && value.IsNil() {
+		return []byte{'n', 'u', 'l', 'l'}, nil
+	}
+
+	var (
+		buf    bytes.Buffer
+		stream = NewStream(&buf)
+	)
+
+	if err := v.MarshalJSONTo(stream); err != nil {
+		return nil, err
+	}
+
+	if err := stream.Flush(); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}


### PR DESCRIPTION
The results of our micro-benchmark shows a 45% improvement in execution time with 64% reduction on number of allocations.

### Before

```bash
$ go test -benchmem -bench=BenchmarkMarshalStarWarsFriendsQueryResultToJSON -run=^$ .
goos: darwin
goarch: amd64
pkg: github.com/botobag/artemis/graphql/executor
BenchmarkMarshalStarWarsFriendsQueryResultToJSONWithGo-8                  100000             12092 ns/op            1986 B/op         16 allocs/op
BenchmarkMarshalStarWarsFriendsQueryResultToJSONWithJsoniter-8            200000              7702 ns/op            1976 B/op         31 allocs/op
PASS
ok      github.com/botobag/artemis/graphql/executor     2.987s
```

### After

```bash
$ go test -benchmem -bench=BenchmarkMarshalStarWarsFriendsQueryResultToJSON -run=^$ .
goos: darwin
goarch: amd64
pkg: github.com/botobag/artemis/graphql/executor
BenchmarkMarshalStarWarsFriendsQueryResultToJSONWithGo-8                  200000             10679 ns/op            3745 B/op         18 allocs/op
BenchmarkMarshalStarWarsFriendsQueryResultToJSONWithJsonwriter-8          300000              4199 ns/op            2656 B/op         11 allocs/op
PASS
ok      github.com/botobag/artemis/graphql/executor     3.585s
```