### PR TITLE
[types] Move graphql.Schema to interface.

### DIFF
--- a/graphql/enum_test.go
+++ b/graphql/enum_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Enum", func() {
 	// graphql-js/src/type/__tests__/enumType-test.js
 	Describe("Type System: Enum Values", func() {
 		var (
-			schema           *graphql.Schema
+			schema           graphql.Schema
 			colorType        graphql.Enum
 			queryType        graphql.Object
 			mutationType     graphql.Object
@@ -623,7 +623,7 @@ var _ = Describe("Enum", func() {
 			var (
 				colorType graphql.Enum
 				queryType graphql.Object
-				schema    *graphql.Schema
+				schema    graphql.Schema
 			)
 
 			BeforeEach(func() {

--- a/graphql/executor/dataloader_test.go
+++ b/graphql/executor/dataloader_test.go
@@ -192,7 +192,7 @@ func (manager *StarWarsDataLoaderManager) CharacterLoadCalls() [][]dataloader.Ke
 
 var _ = Describe("Execute: fetch data with DataLoader", func() {
 	var (
-		schema            *graphql.Schema
+		schema            graphql.Schema
 		runner            concurrent.Executor
 		dataloaderManager *StarWarsDataLoaderManager
 	)

--- a/graphql/executor/execute.go
+++ b/graphql/executor/execute.go
@@ -283,7 +283,7 @@ func shouldIncludeNode(ctx *ExecutionContext, node ast.Selection) (bool, error) 
 // __schema could get automatically added to the query type, but that would require mutating type
 // definitions, which would cause issues.
 func findFieldDef(
-	schema *graphql.Schema,
+	schema graphql.Schema,
 	parentType graphql.Object,
 	fieldName string) graphql.Field {
 	// TODO: Deal with special introspection fields.
@@ -844,7 +844,7 @@ func (task *ExecuteNodeTask) newResolveInfoFor(result *ResultNode) graphql.Resol
 // But a better way is to use "task" as an ResolveInfo object to save allocation overheads.
 
 // Schema implements graphql.ResolveInfo.
-func (task *ExecuteNodeTask) Schema() *graphql.Schema {
+func (task *ExecuteNodeTask) Schema() graphql.Schema {
 	return task.ctx.Operation().Schema()
 }
 

--- a/graphql/executor/execute_test.go
+++ b/graphql/executor/execute_test.go
@@ -1188,7 +1188,7 @@ var _ = DescribeExecute("Execute: Handles basic execution tasks", func(runner co
 	Describe("Provides error when erroneous operation name is provided to query with multiple operations", func() {
 		var (
 			document ast.Document
-			schema   *graphql.Schema
+			schema   graphql.Schema
 		)
 
 		BeforeEach(func() {
@@ -1244,7 +1244,7 @@ var _ = DescribeExecute("Execute: Handles basic execution tasks", func(runner co
 				"a": "b",
 				"c": "d",
 			}
-			schema *graphql.Schema
+			schema graphql.Schema
 		)
 
 		BeforeEach(func() {

--- a/graphql/executor/execution_context.go
+++ b/graphql/executor/execution_context.go
@@ -85,7 +85,7 @@ func (context *ExecutionContext) Operation() *PreparedOperation {
 }
 
 // Schema returns context.operation.Schema().
-func (context *ExecutionContext) Schema() *graphql.Schema {
+func (context *ExecutionContext) Schema() graphql.Schema {
 	return context.operation.Schema()
 }
 

--- a/graphql/executor/prepared_operation.go
+++ b/graphql/executor/prepared_operation.go
@@ -38,7 +38,7 @@ import (
 // [2]: https://facebook.github.io/graphql/draft/#sec-Language.Document
 type PreparedOperation struct {
 	// Schema of the type system that is currently executing
-	schema *graphql.Schema
+	schema graphql.Schema
 
 	// Document that contains definitions for this operation
 	document ast.Document
@@ -60,7 +60,7 @@ type PreparedOperation struct {
 // PrepareParams specifies parameters to Prepare. All data are required except DefaultFieldResolver.
 type PrepareParams struct {
 	// Schema of the type system that this operation is executing on
-	Schema *graphql.Schema
+	Schema graphql.Schema
 
 	// Document that contains operations to be prepared for execution
 	Document ast.Document
@@ -170,7 +170,7 @@ func Prepare(params PrepareParams) (*PreparedOperation, graphql.Errors) {
 }
 
 // Schema returns the type system definition which the operation is based on.
-func (operation *PreparedOperation) Schema() *graphql.Schema {
+func (operation *PreparedOperation) Schema() graphql.Schema {
 	return operation.schema
 }
 

--- a/graphql/executor/resolve_info.go
+++ b/graphql/executor/resolve_info.go
@@ -40,7 +40,7 @@ var (
 )
 
 // Schema implements graphql.ResolveInfo.
-func (info *ResolveInfo) Schema() *graphql.Schema {
+func (info *ResolveInfo) Schema() graphql.Schema {
 	return info.ExecutionContext.Operation().Schema()
 }
 

--- a/graphql/graphql_suite_test.go
+++ b/graphql/graphql_suite_test.go
@@ -34,7 +34,7 @@ func TestGraphQLCore(t *testing.T) {
 	RunSpecs(t, "GraphQL Core Suite")
 }
 
-func executeQueryWithParams(schema *graphql.Schema, query string, params map[string]interface{}) executor.ExecutionResult {
+func executeQueryWithParams(schema graphql.Schema, query string, params map[string]interface{}) executor.ExecutionResult {
 	document, err := parser.Parse(token.NewSource(&token.SourceConfig{
 		Body: token.SourceBody([]byte(query)),
 	}), parser.ParseOptions{})
@@ -53,6 +53,6 @@ func executeQueryWithParams(schema *graphql.Schema, query string, params map[str
 	return result
 }
 
-func executeQuery(schema *graphql.Schema, query string) executor.ExecutionResult {
+func executeQuery(schema graphql.Schema, query string) executor.ExecutionResult {
 	return executeQueryWithParams(schema, query, nil)
 }

--- a/graphql/handler/http_handler.go
+++ b/graphql/handler/http_handler.go
@@ -110,7 +110,7 @@ func OverrideOperationCache(cache OperationCache) Option {
 
 // New creates a net/http.Handler and builds a GraphQL web service to serve queries against the
 // schema.
-func New(schema *graphql.Schema, opts ...Option) (http.Handler, error) {
+func New(schema graphql.Schema, opts ...Option) (http.Handler, error) {
 	// Apply Options on config.
 	config := httpHandlerConfig{
 		LLConfig: LLConfig{
@@ -203,7 +203,7 @@ type DefaultRequestBuilder struct {
 // HTTPHandler provides interfaces to access settings in httpHandler from RequestBuilder.
 type HTTPHandler interface {
 	// Schema served by this handler
-	Schema() *graphql.Schema
+	Schema() graphql.Schema
 
 	// OperationCache for the parsed queries
 	OperationCache() OperationCache

--- a/graphql/handler/low_level_handler.go
+++ b/graphql/handler/low_level_handler.go
@@ -30,7 +30,7 @@ import (
 // such as GraphQL web services.
 type LLHandler struct {
 	// Schema served by this handler
-	schema *graphql.Schema
+	schema graphql.Schema
 
 	// Cache for the parsed query; Could be nil (when the handler was created
 	// with config.OperationCache set to NopOperationCache) to disable cache.
@@ -43,7 +43,7 @@ type LLHandler struct {
 // LLConfig contains configuration to set up a LLHandler.
 type LLConfig struct {
 	// Schema to be working on
-	Schema *graphql.Schema
+	Schema graphql.Schema
 
 	// OperationCache caches graphql.PreparedOperation created from a query to save parsing efforts.
 	OperationCache OperationCache
@@ -81,7 +81,7 @@ func NewLLHandler(config *LLConfig) (*LLHandler, error) {
 }
 
 // Schema returns handler.schema.
-func (handler *LLHandler) Schema() *graphql.Schema {
+func (handler *LLHandler) Schema() graphql.Schema {
 	return handler.schema
 }
 

--- a/graphql/internal/value/variable_coercion.go
+++ b/graphql/internal/value/variable_coercion.go
@@ -27,7 +27,7 @@ import (
 // provided variable definitions and arbitrary input. If the input cannot be parsed to match the
 // variable definitions, a graphql.Error will be raised.
 func CoerceVariableValues(
-	schema *graphql.Schema,
+	schema graphql.Schema,
 	variableDefinitions []*ast.VariableDefinition,
 	inputValues map[string]interface{}) (graphql.VariableValues, graphql.Errors) {
 	var errs graphql.Errors

--- a/graphql/resolve_info.go
+++ b/graphql/resolve_info.go
@@ -233,7 +233,7 @@ type ResolveInfo interface {
 	// executor.PreparedOperation)
 
 	// Schema of the type system that is currently executing.
-	Schema() *Schema
+	Schema() Schema
 
 	// Document that contains definitions for the operation.
 	Document() ast.Document

--- a/graphql/scalar_alias_test.go
+++ b/graphql/scalar_alias_test.go
@@ -151,7 +151,7 @@ var _ = Describe("ScalarAlias", func() {
 			Num  int
 		}
 
-		var Schema *graphql.Schema
+		var Schema graphql.Schema
 
 		BeforeEach(func() {
 			userIDType := &graphql.ScalarAliasConfig{

--- a/graphql/schema_test.go
+++ b/graphql/schema_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Type System: Schema", func() {
 		DirectiveInputType        graphql.InputObject
 		WrappedDirectiveInputType graphql.InputObject
 		Directive                 *graphql.Directive
-		Schema                    *graphql.Schema
+		Schema                    graphql.Schema
 	)
 
 	BeforeEach(func() {


### PR DESCRIPTION
`graphql.Schema` states the requirements of a `Schema` object to be work with the execution engine instead of being an actual implementation. `graphql.NewSchema` provides a default implementation which creates an `Schema` object from `SchemaConfig`. This may enables other `Schema` variants such as [remote schema](https://www.apollographql.com/docs/graphql-tools/remote-schemas.html) or [schema stitching](https://www.apollographql.com/docs/graphql-tools/schema-stitching.html)

Closes #82.