### PR TITLE
[ci] Enable test build with Go 1.12 in CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,12 +58,16 @@ jobs:
     docker: [{ image: 'circleci/golang:1.11' }]
     <<: *defaults
 
+  Go 1.12:
+    docker: [{ image: 'circleci/golang:1.12' }]
+    <<: *defaults
+
   Go latest:
     docker: [{ image: 'circleci/golang:latest' }]
     <<: *defaults
 
   codecov:
-    docker: [{ image: 'circleci/golang:1.11' }]
+    docker: [{ image: 'circleci/golang:latest' }]
     steps:
       - checkout
       # See:
@@ -88,5 +92,6 @@ workflows:
       - Go 1.9
       - Go 1.10
       - Go 1.11
+      - Go 1.12
       - Go latest
       - codecov


### PR DESCRIPTION
Closes #150.