### PR TITLE
[types] Remove String() from Type objects.

### DIFF
--- a/graphql/directive_test.go
+++ b/graphql/directive_test.go
@@ -93,12 +93,4 @@ var _ = Describe("Directive", func() {
 			graphql.MustNewDirective(&graphql.DirectiveConfig{})
 		}).Should(Panic())
 	})
-
-	It("stringifies to GraphQL notation", func() {
-		directiveType, err := graphql.NewDirective(&graphql.DirectiveConfig{
-			Name: "directive",
-		})
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(graphql.Inspect(directiveType)).Should(Equal("@directive"))
-	})
 })

--- a/graphql/enum.go
+++ b/graphql/enum.go
@@ -359,11 +359,6 @@ func MustNewEnum(typeDef EnumTypeDefinition) Enum {
 	return e
 }
 
-// String implemennts fmt.Stringer.
-func (e *enum) String() string {
-	return e.Name()
-}
-
 // Name implemennts TypeWithName.
 func (e *enum) Name() string {
 	return e.data.Name

--- a/graphql/enum_test.go
+++ b/graphql/enum_test.go
@@ -18,7 +18,6 @@ package graphql_test
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/botobag/artemis/graphql"
 	"github.com/botobag/artemis/internal/testutil"
@@ -720,15 +719,6 @@ var _ = Describe("Enum", func() {
 				}))
 			})
 		})
-	})
-
-	It("stringifies to type name", func() {
-		enumType, err := graphql.NewEnum(&graphql.EnumConfig{
-			Name: "Enum",
-		})
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(fmt.Sprintf("%s", enumType)).Should(Equal("Enum"))
-		Expect(fmt.Sprintf("%v", enumType)).Should(Equal("Enum"))
 	})
 
 	It("rejects creating type without name", func() {

--- a/graphql/executor/execute.go
+++ b/graphql/executor/execute.go
@@ -880,7 +880,7 @@ func (task *ExecuteNodeTask) completeAbstractValue(
 			graphql.NewError(
 				fmt.Sprintf("Abstract type %s must provide resolver to resolve to an Object type at "+
 					"runtime for field %s.%s with value %s",
-					returnType, parentFieldType(ctx, node).Name(), node.Field.Name(),
+					returnType.Name(), parentFieldType(ctx, node).Name(), node.Field.Name(),
 					graphql.Inspect(value))), result)
 		return false
 	}
@@ -896,7 +896,7 @@ func (task *ExecuteNodeTask) completeAbstractValue(
 			graphql.NewError(
 				fmt.Sprintf("Abstract type %s must resolve to an Object type at runtime for field %s.%s "+
 					"with value %s, received nil.",
-					returnType, parentFieldType(ctx, node).Name(), node.Field.Name(),
+					returnType.Name(), parentFieldType(ctx, node).Name(), node.Field.Name(),
 					graphql.Inspect(value))), result)
 		return false
 	}
@@ -906,7 +906,7 @@ func (task *ExecuteNodeTask) completeAbstractValue(
 		task.handleNodeError(
 			graphql.NewError(
 				fmt.Sprintf(`Runtime Object type "%s" is not a possible type for "%s".`,
-					runtimeType, returnType)), result)
+					runtimeType.Name(), returnType.Name())), result)
 		return false
 	}
 

--- a/graphql/input_object.go
+++ b/graphql/input_object.go
@@ -212,11 +212,6 @@ func MustNewInputObject(typeDef InputObjectTypeDefinition) InputObject {
 	return o
 }
 
-// String implemennts fmt.Stringer.
-func (o *inputObject) String() string {
-	return o.Name()
-}
-
 // Name implemennts TypeWithName.
 func (o *inputObject) Name() string {
 	return o.data.Name

--- a/graphql/input_object_test.go
+++ b/graphql/input_object_test.go
@@ -17,8 +17,6 @@
 package graphql_test
 
 import (
-	"fmt"
-
 	"github.com/botobag/artemis/graphql"
 
 	. "github.com/onsi/ginkgo"
@@ -58,15 +56,6 @@ var _ = Describe("InputObject", func() {
 				Type: graphql.T(graphql.String()),
 			},
 		}))
-	})
-
-	It("stringifies to type name", func() {
-		inputObjectType, err := graphql.NewInputObject(&graphql.InputObjectConfig{
-			Name: "InputObject",
-		})
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(fmt.Sprintf("%s", inputObjectType)).Should(Equal("InputObject"))
-		Expect(fmt.Sprintf("%v", inputObjectType)).Should(Equal("InputObject"))
 	})
 
 	It("accepts creating type without fields", func() {

--- a/graphql/inspect_test.go
+++ b/graphql/inspect_test.go
@@ -293,4 +293,68 @@ var _ = Describe("Inspect", func() {
 		}
 		Expect(graphql.Inspect([][]*Foo{{&Foo{}}})).Should(Equal("[[[Foo]]]"))
 	})
+
+	It("stringifies Type object", func() {
+		// Scalar
+		scalarType := graphql.MustNewScalar(&graphql.ScalarConfig{
+			Name: "Scalar",
+			ResultCoercer: graphql.CoerceScalarResultFunc(func(value interface{}) (interface{}, error) {
+				return nil, nil
+			}),
+		})
+		Expect(graphql.Inspect(scalarType)).Should(Equal("Scalar"))
+
+		// Object
+		objectType := graphql.MustNewObject(&graphql.ObjectConfig{
+			Name: "Object",
+		})
+		Expect(graphql.Inspect(objectType)).Should(Equal("Object"))
+
+		// Interface
+		interfaceType := graphql.MustNewInterface(&graphql.InterfaceConfig{
+			Name: "Interface",
+		})
+		Expect(graphql.Inspect(interfaceType)).Should(Equal("Interface"))
+
+		// Union
+		unionType := graphql.MustNewUnion(&graphql.UnionConfig{
+			Name: "Union",
+		})
+		Expect(graphql.Inspect(unionType)).Should(Equal("Union"))
+
+		// Enum
+		enumType := graphql.MustNewEnum(&graphql.EnumConfig{
+			Name: "Enum",
+		})
+		Expect(graphql.Inspect(enumType)).Should(Equal("Enum"))
+
+		// InputObject
+		inputObjectType := graphql.MustNewInputObject(&graphql.InputObjectConfig{
+			Name: "InputObject",
+		})
+		Expect(graphql.Inspect(inputObjectType)).Should(Equal("InputObject"))
+
+		// List & NonNull
+		listType := graphql.MustNewListOfType(graphql.Int())
+		Expect(graphql.Inspect(listType)).Should(Equal("[Int]"))
+
+		nonNullListType := graphql.MustNewNonNullOfType(listType)
+		Expect(graphql.Inspect(nonNullListType)).Should(Equal("[Int]!"))
+
+		nonNullType := graphql.MustNewNonNullOfType(graphql.Int())
+		Expect(graphql.Inspect(nonNullType)).Should(Equal("Int!"))
+
+		listNonNullType := graphql.MustNewListOfType(nonNullType)
+		Expect(graphql.Inspect(listNonNullType)).Should(Equal("[Int!]"))
+
+		listListType := graphql.MustNewListOfType(listType)
+		Expect(graphql.Inspect(listListType)).Should(Equal("[[Int]]"))
+	})
+
+	It("stringifies Directive", func() {
+		directiveType := graphql.MustNewDirective(&graphql.DirectiveConfig{
+			Name: "directive",
+		})
+		Expect(graphql.Inspect(directiveType)).Should(Equal("@directive"))
+	})
 })

--- a/graphql/interface.go
+++ b/graphql/interface.go
@@ -137,11 +137,6 @@ func MustNewInterface(typeDef InterfaceTypeDefinition) Interface {
 	return iface
 }
 
-// String implements fmt.Stringer.
-func (iface *iface) String() string {
-	return iface.Name()
-}
-
 // TypeResolver implements AbstractType.
 func (iface *iface) TypeResolver() TypeResolver {
 	return iface.typeResolver

--- a/graphql/interface_test.go
+++ b/graphql/interface_test.go
@@ -17,8 +17,6 @@
 package graphql_test
 
 import (
-	"fmt"
-
 	"github.com/botobag/artemis/graphql"
 
 	. "github.com/onsi/ginkgo"
@@ -26,21 +24,6 @@ import (
 )
 
 var _ = Describe("Interface", func() {
-	var InterfaceType graphql.Interface
-
-	BeforeEach(func() {
-		var err error
-		InterfaceType, err = graphql.NewInterface(&graphql.InterfaceConfig{
-			Name: "Interface",
-		})
-		Expect(err).ShouldNot(HaveOccurred())
-	})
-
-	It("stringifies to type name", func() {
-		Expect(fmt.Sprintf("%s", InterfaceType)).Should(Equal("Interface"))
-		Expect(fmt.Sprintf("%v", InterfaceType)).Should(Equal("Interface"))
-	})
-
 	It("rejects creating type without name", func() {
 		_, err := graphql.NewInterface(&graphql.InterfaceConfig{
 			Name: "",

--- a/graphql/list_test.go
+++ b/graphql/list_test.go
@@ -24,29 +24,6 @@ import (
 )
 
 var _ = Describe("List", func() {
-
-	It("stringifies to GraphQL notation", func() {
-		listType, err := graphql.NewListOfType(graphql.Int())
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(graphql.Inspect(listType)).Should(Equal("[Int]"))
-
-		nonNullListType, err := graphql.NewNonNullOfType(listType)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(graphql.Inspect(nonNullListType)).Should(Equal("[Int]!"))
-
-		nonNullType, err := graphql.NewNonNullOfType(graphql.Int())
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(graphql.Inspect(nonNullType)).Should(Equal("Int!"))
-
-		listNonNullType, err := graphql.NewListOfType(nonNullType)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(graphql.Inspect(listNonNullType)).Should(Equal("[Int!]"))
-
-		listListType, err := graphql.NewListOfType(listType)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(graphql.Inspect(listListType)).Should(Equal("[[Int]]"))
-	})
-
 	It("defines list with TypeDefinition", func() {
 		// Create [Int].
 		listType, err := graphql.NewListOf(graphql.T(graphql.Int()))

--- a/graphql/non_null_test.go
+++ b/graphql/non_null_test.go
@@ -33,12 +33,6 @@ var _ = Describe("NonNull", func() {
 		Expect(err).Should(MatchError("Expected a nullable type for NonNull but got an Int!."))
 	})
 
-	It("stringifies to GraphQL notation", func() {
-		nonNullType, err := graphql.NewNonNullOfType(graphql.Int())
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(graphql.Inspect(nonNullType)).Should(Equal("Int!"))
-	})
-
 	It("rejects creating type without specifying element type", func() {
 		_, err := graphql.NewNonNullOfType(nil)
 		Expect(err).Should(MatchError("Must provide an non-nil element type for NonNull."))

--- a/graphql/object.go
+++ b/graphql/object.go
@@ -139,11 +139,6 @@ func MustNewObject(typeDef ObjectTypeDefinition) Object {
 	return o
 }
 
-// String implements fmt.Stringer.
-func (o *object) String() string {
-	return o.Name()
-}
-
 // Name implements TypeWithName.
 func (o *object) Name() string {
 	return o.data.Name

--- a/graphql/object_test.go
+++ b/graphql/object_test.go
@@ -17,8 +17,6 @@
 package graphql_test
 
 import (
-	"fmt"
-
 	"github.com/botobag/artemis/graphql"
 
 	. "github.com/onsi/ginkgo"
@@ -136,15 +134,6 @@ var _ = Describe("Object", func() {
 				},
 			},
 		}))
-	})
-
-	It("stringifies to type name", func() {
-		objectType, err := graphql.NewObject(&graphql.ObjectConfig{
-			Name: "Object",
-		})
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(fmt.Sprintf("%s", objectType)).Should(Equal("Object"))
-		Expect(fmt.Sprintf("%v", objectType)).Should(Equal("Object"))
 	})
 
 	It("rejects creating type without name", func() {

--- a/graphql/scalar.go
+++ b/graphql/scalar.go
@@ -172,11 +172,6 @@ func MustNewScalar(typeDef ScalarTypeDefinition) Scalar {
 	return s
 }
 
-// String implements fmt.Stringer.
-func (s *scalar) String() string {
-	return s.Name()
-}
-
 // Name implements TypeWithName.
 func (s *scalar) Name() string {
 	return s.data.Name

--- a/graphql/scalar_test.go
+++ b/graphql/scalar_test.go
@@ -17,8 +17,6 @@
 package graphql_test
 
 import (
-	"fmt"
-
 	"github.com/botobag/artemis/graphql"
 	"github.com/botobag/artemis/graphql/ast"
 
@@ -89,18 +87,6 @@ var _ = Describe("Scalar", func() {
 			_, err = schemaWithFieldType(scalar)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
-	})
-
-	It("stringifies to type name", func() {
-		scalarType, err := graphql.NewScalar(&graphql.ScalarConfig{
-			Name: "Scalar",
-			ResultCoercer: graphql.CoerceScalarResultFunc(func(value interface{}) (interface{}, error) {
-				return nil, nil
-			}),
-		})
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(fmt.Sprintf("%s", scalarType)).Should(Equal("Scalar"))
-		Expect(fmt.Sprintf("%v", scalarType)).Should(Equal("Scalar"))
 	})
 
 	It("rejects creating type without name", func() {

--- a/graphql/union.go
+++ b/graphql/union.go
@@ -139,11 +139,6 @@ func MustNewUnion(typeDef UnionTypeDefinition) Union {
 	return u
 }
 
-// String implements fmt.Stringer.
-func (u *union) String() string {
-	return u.Name()
-}
-
 // TypeResolver implements AbstractType.
 func (u *union) TypeResolver() TypeResolver {
 	return u.typeResolver

--- a/graphql/union_test.go
+++ b/graphql/union_test.go
@@ -17,8 +17,6 @@
 package graphql_test
 
 import (
-	"fmt"
-
 	"github.com/botobag/artemis/graphql"
 
 	. "github.com/onsi/ginkgo"
@@ -26,15 +24,6 @@ import (
 )
 
 var _ = Describe("Union", func() {
-	It("stringifies to type name", func() {
-		unionType, err := graphql.NewUnion(&graphql.UnionConfig{
-			Name: "Union",
-		})
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(fmt.Sprintf("%s", unionType)).Should(Equal("Union"))
-		Expect(fmt.Sprintf("%v", unionType)).Should(Equal("Union"))
-	})
-
 	It("accepts empty set of possible types", func() {
 		emptyPossibleSet := graphql.NewPossibleTypeSet()
 


### PR DESCRIPTION
  * Gather type printing tests in each type tests to `inspect_test.go`.
  * Replace `fmt.Sprintf("%s", <Type>)` with `graphql.Inspect` or
   `.Name()`.