### PR TITLE
[type] Rename CoerceScalarResultFunc to ScalarResultCoercerFunc.

### DIFF
--- a/graphql/inspect_test.go
+++ b/graphql/inspect_test.go
@@ -298,7 +298,7 @@ var _ = Describe("Inspect", func() {
 		// Scalar
 		scalarType := graphql.MustNewScalar(&graphql.ScalarConfig{
 			Name: "Scalar",
-			ResultCoercer: graphql.CoerceScalarResultFunc(func(value interface{}) (interface{}, error) {
+			ResultCoercer: graphql.ScalarResultCoercerFunc(func(value interface{}) (interface{}, error) {
 				return nil, nil
 			}),
 		})

--- a/graphql/scalar_test.go
+++ b/graphql/scalar_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Scalar", func() {
 		It("accepts a Scalar type defining serialize", func() {
 			scalar := graphql.MustNewScalar(&graphql.ScalarConfig{
 				Name: "SomeScalar",
-				ResultCoercer: graphql.CoerceScalarResultFunc(func(value interface{}) (interface{}, error) {
+				ResultCoercer: graphql.ScalarResultCoercerFunc(func(value interface{}) (interface{}, error) {
 					return nil, nil
 				}),
 			})
@@ -65,7 +65,7 @@ var _ = Describe("Scalar", func() {
 		It("accepts a Scalar type defining input parser", func() {
 			scalar := graphql.MustNewScalar(&graphql.ScalarConfig{
 				Name: "SomeScalar",
-				ResultCoercer: graphql.CoerceScalarResultFunc(func(value interface{}) (interface{}, error) {
+				ResultCoercer: graphql.ScalarResultCoercerFunc(func(value interface{}) (interface{}, error) {
 					return nil, nil
 				}),
 				InputCoercer: graphql.ScalarInputCoercerFuncs{

--- a/graphql/schema_test.go
+++ b/graphql/schema_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Type System: Schema", func() {
 		It("rejects a Schema which redefines a built-in type", func() {
 			FakeString := graphql.MustNewScalar(&graphql.ScalarConfig{
 				Name: "String",
-				ResultCoercer: graphql.CoerceScalarResultFunc(func(value interface{}) (interface{}, error) {
+				ResultCoercer: graphql.ScalarResultCoercerFunc(func(value interface{}) (interface{}, error) {
 					return nil, nil
 				}),
 			})

--- a/graphql/types.go
+++ b/graphql/types.go
@@ -156,17 +156,17 @@ type ScalarResultCoercer interface {
 	CoerceResultValue(value interface{}) (interface{}, error)
 }
 
-// CoerceScalarResultFunc is an adapter to allow the use of ordinary functions as
+// ScalarResultCoercerFunc is an adapter to allow the use of ordinary functions as
 // ScalarResultCoercer.
-type CoerceScalarResultFunc func(value interface{}) (interface{}, error)
+type ScalarResultCoercerFunc func(value interface{}) (interface{}, error)
 
 // CoerceResultValue calls f(value).
-func (f CoerceScalarResultFunc) CoerceResultValue(value interface{}) (interface{}, error) {
+func (f ScalarResultCoercerFunc) CoerceResultValue(value interface{}) (interface{}, error) {
 	return f(value)
 }
 
-// CoerceScalarResultFunc implements ScalarResultCoercer.
-var _ ScalarResultCoercer = (CoerceScalarResultFunc)(nil)
+// ScalarResultCoercerFunc implements ScalarResultCoercer.
+var _ ScalarResultCoercer = (ScalarResultCoercerFunc)(nil)
 
 // ScalarInputCoercer coerces input values in the GraphQL requests into a value represented the
 // Scalar type. Please read "Input Coercion" in [0] to provide appropriate implementation.

--- a/graphql/types_test.go
+++ b/graphql/types_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Type", func() {
 	BeforeEach(func() {
 		ScalarType = graphql.MustNewScalar(&graphql.ScalarConfig{
 			Name: "Scalar",
-			ResultCoercer: graphql.CoerceScalarResultFunc(
+			ResultCoercer: graphql.ScalarResultCoercerFunc(
 				func(value interface{}) (interface{}, error) {
 					return nil, nil
 				}),

--- a/graphql/validator/rules/rules_suite_test.go
+++ b/graphql/validator/rules/rules_suite_test.go
@@ -433,7 +433,7 @@ var ComplicatedArgs = &graphql.ObjectConfig{
 
 var InvalidScalar = &graphql.ScalarConfig{
 	Name: "Invalid",
-	ResultCoercer: graphql.CoerceScalarResultFunc(func(value interface{}) (interface{}, error) {
+	ResultCoercer: graphql.ScalarResultCoercerFunc(func(value interface{}) (interface{}, error) {
 		return value, nil
 	}),
 	InputCoercer: graphql.ScalarInputCoercerFuncs{
@@ -448,7 +448,7 @@ var InvalidScalar = &graphql.ScalarConfig{
 
 var AnyScalar = &graphql.ScalarConfig{
 	Name: "Any",
-	ResultCoercer: graphql.CoerceScalarResultFunc(func(value interface{}) (interface{}, error) {
+	ResultCoercer: graphql.ScalarResultCoercerFunc(func(value interface{}) (interface{}, error) {
 		return value, nil
 	}),
 	InputCoercer: graphql.ScalarInputCoercerFuncs{


### PR DESCRIPTION
Closes #170.